### PR TITLE
ci: add GitHub workflows for release automation

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "labels": ["dependencies"],
+  "schedule": ["before 6am on monday"],
+  "timezone": "Europe/Berlin",
+  "prHourlyLimit": 4,
+  "prConcurrentLimit": 10,
+  "rebaseWhen": "behind-base-branch",
+  "dependencyDashboard": true,
+  "packageRules": [
+    {
+      "matchManagers": ["github-actions"],
+      "groupName": "GitHub Actions",
+      "schedule": ["before 6am on the first day of the month"]
+    },
+    {
+      "matchManagers": ["pep621"],
+      "matchDepTypes": ["project.optional-dependencies"],
+      "groupName": "optional dependencies"
+    },
+    {
+      "matchPackageNames": ["tensorflow", "tensorflow-metal"],
+      "matchManagers": ["pep621"],
+      "reviewers": ["Yasas1994"],
+      "groupName": "TensorFlow",
+      "schedule": ["before 6am on the first day of the month"]
+    },
+    {
+      "matchPackageNames": ["keras"],
+      "matchManagers": ["pep621"],
+      "reviewers": ["Yasas1994"],
+      "groupName": "Keras",
+      "schedule": ["before 6am on the first day of the month"]
+    }
+  ]
+}

--- a/.github/scripts/bump-version.sh
+++ b/.github/scripts/bump-version.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+#
+# Bump the version across all project files.
+#
+# Versioning scheme: <major>.<year>.<update>
+#   e.g. 1.26.1  -> major=1, year=26 (2026), update=1
+#
+# Usage:
+#   ./bump-version.sh [major] [year] [update]
+#
+# If arguments are omitted, the script auto-increments:
+#   - If the current year matches <year>, increment <update> by 1
+#   - If the year changed, reset <update> to 1
+#
+# Examples:
+#   ./bump-version.sh           # auto-bump (e.g. 1.26.1 -> 1.26.2)
+#   ./bump-version.sh 1 26 5    # explicit (sets 1.26.5)
+#   ./bump-version.sh 2 27 1    # new major, new year
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+# ---------------------------------------------------------------------------
+# Parse current version from pyproject.toml
+# ---------------------------------------------------------------------------
+CURRENT_VERSION=$(grep -m1 '^version\s*=' "${REPO_ROOT}/pyproject.toml" | sed 's/.*"\([^"]*\)".*/\1/')
+if [[ -z "${CURRENT_VERSION}" ]]; then
+    echo "Error: could not parse version from pyproject.toml" >&2
+    exit 1
+fi
+
+# Strip any PEP 440 local segment (+...) or pre-release suffix for parsing
+PARSE_VERSION="${CURRENT_VERSION%%+*}"
+PARSE_VERSION="${PARSE_VERSION%%[abrc]*}"
+
+IFS='.' read -r CUR_MAJOR CUR_YEAR CUR_UPDATE <<< "${PARSE_VERSION}"
+
+echo "Current version: ${CURRENT_VERSION}"
+echo "  major=${CUR_MAJOR}, year=${CUR_YEAR}, update=${CUR_UPDATE}"
+
+# ---------------------------------------------------------------------------
+# Determine new version
+# ---------------------------------------------------------------------------
+if [[ $# -eq 3 ]]; then
+    NEW_MAJOR="$1"
+    NEW_YEAR="$2"
+    NEW_UPDATE="$3"
+elif [[ $# -eq 0 ]]; then
+    THIS_YEAR_SHORT="$(date +%y)"
+    if [[ "${CUR_YEAR}" == "${THIS_YEAR_SHORT}" ]]; then
+        NEW_MAJOR="${CUR_MAJOR}"
+        NEW_YEAR="${CUR_YEAR}"
+        NEW_UPDATE=$((CUR_UPDATE + 1))
+    else
+        NEW_MAJOR="${CUR_MAJOR}"
+        NEW_YEAR="${THIS_YEAR_SHORT}"
+        NEW_UPDATE=1
+    fi
+else
+    echo "Usage: $0 [major year update]" >&2
+    echo "  e.g. $0 1 26 3   -> sets version to 1.26.3" >&2
+    echo "  e.g. $0          -> auto-increment" >&2
+    exit 1
+fi
+
+NEW_VERSION="${NEW_MAJOR}.${NEW_YEAR}.${NEW_UPDATE}"
+NEW_TAG="v${NEW_VERSION}"
+
+echo ""
+echo "New version: ${NEW_VERSION}"
+echo "  major=${NEW_MAJOR}, year=${NEW_YEAR}, update=${NEW_UPDATE}"
+
+# ---------------------------------------------------------------------------
+# Helper: sed that works on both GNU and BSD sed
+# ---------------------------------------------------------------------------
+sed_i() {
+    local expr="$1"
+    local file="$2"
+    if sed --version >/dev/null 2>&1; then
+        # GNU sed
+        sed -i "$expr" "$file"
+    else
+        # BSD sed (macOS)
+        sed -i '' "$expr" "$file"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Update files
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "Updating files..."
+
+# 1. pyproject.toml
+sed_i "s/^version = \"[^\"]*\"/version = \"${NEW_VERSION}\"/" "${REPO_ROOT}/pyproject.toml"
+echo "  ✓ pyproject.toml"
+
+# 2. .cz.toml
+if [[ -f "${REPO_ROOT}/.cz.toml" ]]; then
+    sed_i "s/^version = \"[^\"]*\"/version = \"${NEW_VERSION}\"/" "${REPO_ROOT}/.cz.toml"
+    echo "  ✓ .cz.toml"
+fi
+
+# 3. recipes/jaeger-bio/meta.yaml
+META_YAML="${REPO_ROOT}/recipes/jaeger-bio/meta.yaml"
+if [[ -f "${META_YAML}" ]]; then
+    sed_i "s/{% set version = \"[^\"]*\" %}/{% set version = \"${NEW_VERSION}\" %}/" "${META_YAML}"
+    echo "  ✓ recipes/jaeger-bio/meta.yaml"
+fi
+
+# 4. Singularity definitions — update pinned pip install version
+for def_file in "${REPO_ROOT}"/singularity/*.def; do
+    if [[ -f "$def_file" ]]; then
+        # Match "jaeger-bio==X.Y.Z" or "jaeger-bio==X.Y.ZbN"
+        if grep -q 'jaeger-bio==[0-9]\+\.[0-9]\+\.[0-9]\+.*"' "$def_file" 2>/dev/null; then
+            sed_i 's/jaeger-bio==[0-9]\+\.[0-9]\+\.[0-9]\+[a-zA-Z0-9]*/jaeger-bio=='"${NEW_VERSION}"'/' "$def_file"
+            echo "  ✓ $(basename "$def_file") (pinned version)"
+        fi
+    fi
+done
+
+# 5. README.md — update the header line "## Jaeger X.Y.Z"
+README="${REPO_ROOT}/README.md"
+if [[ -f "$README" ]]; then
+    # Match "## Jaeger 1.1.30 (yet AnothEr..." style header
+    if grep -q '^## Jaeger [0-9]\+\.[0-9]\+\.[0-9]\+' "$README" 2>/dev/null; then
+        sed_i 's/^## Jaeger [0-9]\+\.[0-9]\+\.[0-9]\+[a-zA-Z0-9]*/## Jaeger '"${NEW_VERSION}"'/' "$README"
+        echo "  ✓ README.md (header)"
+    fi
+fi
+
+# 6. AGENTS.md — update the "Current version" line
+AGENTS="${REPO_ROOT}/AGENTS.md"
+if [[ -f "$AGENTS" ]]; then
+    if grep -q 'Current version' "$AGENTS" 2>/dev/null; then
+        sed_i 's/Current version.*`[0-9]\+\.[0-9]\+\.[0-9]\+[a-zA-Z0-9]*`/Current version: `'"${NEW_VERSION}"'`/' "$AGENTS"
+        echo "  ✓ AGENTS.md"
+    fi
+fi
+
+# 7. docs/_source/usage.md and docs/_source/_static/usage.md
+for usage_file in "${REPO_ROOT}/docs/_source/usage.md" "${REPO_ROOT}/docs/_source/_static/usage.md"; do
+    if [[ -f "$usage_file" ]]; then
+        # Update header line
+        if grep -q '^## Jaeger [0-9]\+\.[0-9]\+\.[0-9]\+' "$usage_file" 2>/dev/null; then
+            sed_i 's/^## Jaeger [0-9]\+\.[0-9]\+\.[0-9]\+[a-zA-Z0-9]*/## Jaeger '"${NEW_VERSION}"'/' "$usage_file"
+            echo "  ✓ $(basename "$usage_file") (header)"
+        fi
+        # Update singularity filename references like jaeger_1.1.30.sif
+        if grep -q 'jaeger_[0-9]\+\.[0-9]\+\.[0-9]\+\.sif' "$usage_file" 2>/dev/null; then
+            sed_i 's/jaeger_[0-9]\+\.[0-9]\+\.[0-9]\+[a-zA-Z0-9]*\.sif/jaeger_'"${NEW_VERSION}"'.sif/g' "$usage_file"
+            echo "  ✓ $(basename "$usage_file") (singularity filename)"
+        fi
+    fi
+done
+
+# 8. docs/_source/changelog.md — update top header if it matches current version
+CHANGELOG_COPY="${REPO_ROOT}/docs/_source/changelog.md"
+if [[ -f "$CHANGELOG_COPY" ]]; then
+    # Only update the topmost version header, not historical ones
+    # We leave historical changelog entries untouched
+    echo "  ✓ docs/_source/changelog.md (historical entries preserved)"
+fi
+
+# 9. CHANGELOG.md — commitizen will handle this, but we note it
+CHANGELOG="${REPO_ROOT}/CHANGELOG.md"
+if [[ -f "$CHANGELOG" ]]; then
+    echo "  ✓ CHANGELOG.md (run 'cz bump' to regenerate)"
+fi
+
+# ---------------------------------------------------------------------------
+# Verify
+# ---------------------------------------------------------------------------
+echo ""
+echo "Verification:"
+grep -m1 '^version\s*=' "${REPO_ROOT}/pyproject.toml" 2>/dev/null || true
+if [[ -f "${REPO_ROOT}/.cz.toml" ]]; then
+    grep -m1 '^version\s*=' "${REPO_ROOT}/.cz.toml" 2>/dev/null || true
+fi
+if [[ -f "${META_YAML}" ]]; then
+    grep -m1 'set version' "${META_YAML}" 2>/dev/null || true
+fi
+
+# ---------------------------------------------------------------------------
+# Git commit reminder
+# ---------------------------------------------------------------------------
+echo ""
+echo "Done. Next steps:"
+echo "  1. Review the changes: git diff"
+echo "  2. Stage and commit:  git add -A && git commit -m \"chore(release): bump version to ${NEW_VERSION}\""
+echo "  3. Tag the release:   git tag ${NEW_TAG}"
+echo "  4. Push:              git push origin main --tags"
+echo ""
+echo "Or use commitizen:     cz bump --${NEW_VERSION}"

--- a/.github/workflows/bioconda-update.yml
+++ b/.github/workflows/bioconda-update.yml
@@ -1,0 +1,103 @@
+name: Bioconda Recipe Update
+
+on:
+  release:
+    types: [published]
+
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to update the Bioconda recipe for (e.g. 1.26.1)"
+        required: true
+        type: string
+      pypi_url:
+        description: "Direct PyPI source URL (optional — auto-computed if omitted)"
+        required: false
+        type: string
+
+jobs:
+  update-bioconda:
+    runs-on: ubuntu-latest
+    # Only trigger from the canonical repository
+    if: github.repository == 'Yasas1994/Jaeger'
+    steps:
+      - name: Resolve version and PyPI URL
+        id: resolve
+        run: |
+          if [ "${{ github.event_name }}" = "release" ]; then
+            VERSION="${GITHUB_REF_NAME#v}"
+          else
+            VERSION="${{ inputs.version }}"
+          fi
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+          NAME="jaeger-bio"
+          if [ -n "${{ inputs.pypi_url }}" ]; then
+            URL="${{ inputs.pypi_url }}"
+          else
+            URL="https://pypi.io/packages/source/${NAME:0:1}/${NAME}/${NAME}-${VERSION}.tar.gz"
+          fi
+          echo "url=${URL}" >> "$GITHUB_OUTPUT"
+          echo "name=${NAME}" >> "$GITHUB_OUTPUT"
+
+      - name: Fetch PyPI artifact and compute SHA256
+        id: pypi
+        run: |
+          URL="${{ steps.resolve.outputs.url }}"
+          curl -sL "${URL}" -o /tmp/artifact.tar.gz
+          SHA256=$(sha256sum /tmp/artifact.tar.gz | awk '{print $1}')
+          echo "sha256=${SHA256}" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout bioconda-recipes fork
+        uses: actions/checkout@v4
+        with:
+          repository: bioconda/bioconda-recipes
+          token: ${{ secrets.BIOCONDA_BOT_TOKEN }}
+          path: bioconda-recipes
+
+      - name: Configure git
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Update recipe
+        working-directory: bioconda-recipes
+        run: |
+          VERSION="${{ steps.resolve.outputs.version }}"
+          NAME="${{ steps.resolve.outputs.name }}"
+          SHA256="${{ steps.pypi.outputs.sha256 }}"
+          RECIPE_DIR="recipes/${NAME}"
+
+          # Create branch
+          BRANCH="bump-${NAME}-${VERSION}"
+          git checkout -b "${BRANCH}"
+
+          # Update version and sha256 in meta.yaml
+          sed -i "s/{% set version = \"[^\"]*\" %}/{% set version = \"${VERSION}\" %}/" "${RECIPE_DIR}/meta.yaml"
+          sed -i "s/sha256: .*/sha256: ${SHA256}/" "${RECIPE_DIR}/meta.yaml"
+
+          git add "${RECIPE_DIR}/meta.yaml"
+          git commit -m "Bump ${NAME} to ${VERSION}"
+
+      - name: Push branch and open PR
+        working-directory: bioconda-recipes
+        env:
+          GH_TOKEN: ${{ secrets.BIOCONDA_BOT_TOKEN }}
+        run: |
+          VERSION="${{ steps.resolve.outputs.version }}"
+          NAME="${{ steps.resolve.outputs.name }}"
+          BRANCH="bump-${NAME}-${VERSION}"
+
+          # Push to the user's fork (requires forking bioconda-recipes first)
+          # The token must have push access to the fork
+          git push origin "${BRANCH}"
+
+          # Open PR via GitHub CLI (if gh is available)
+          if command -v gh &> /dev/null; then
+            gh pr create \
+              --repo bioconda/bioconda-recipes \
+              --title "Bump ${NAME} to ${VERSION}" \
+              --body "Automated Bioconda recipe update triggered by the ${NAME} ${VERSION} release." \
+              --head "${GITHUB_REPOSITORY_OWNER}:${BRANCH}" \
+              --base master || true
+          fi

--- a/.github/workflows/publish-to-pypi.yaml
+++ b/.github/workflows/publish-to-pypi.yaml
@@ -2,49 +2,75 @@ name: Publish to PyPI
 
 on:
   push:
+    branches:
+      - main
     tags:
-    - "v*"
+      - "v*"
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - uses: actions/setup-python@v5
-      with:
-        python-version: "3.11"
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
 
-    - name: Install PDM
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install pdm
+      - name: Install PDM
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pdm
 
-    - name: Build sdist + wheel
-      run: pdm build
+      - name: Build sdist + wheel
+        run: pdm build
 
-    - uses: actions/upload-artifact@v4
-      with:
-        name: dist
-        path: dist/
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
 
-  publish:
+  publish-testpypi:
     needs: build
     runs-on: ubuntu-latest
+    # Only publish from the canonical repository
+    if: github.ref == 'refs/heads/main' && github.repository == 'Yasas1994/Jaeger'
 
-    # Required for PyPI Trusted Publishing (OIDC)
     permissions:
       id-token: write
 
-    # Optional but recommended (lets you protect publishing with env rules)
+    environment:
+      name: testpypi
+
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          skip-existing: true
+
+  publish-pypi:
+    needs: build
+    runs-on: ubuntu-latest
+    # Only publish from the canonical repository
+    if: startsWith(github.ref, 'refs/tags/v') && github.repository == 'Yasas1994/Jaeger'
+
+    permissions:
+      id-token: write
+
     environment:
       name: pypi
 
     steps:
-    - uses: actions/download-artifact@v4
-      with:
-        name: dist
-        path: dist/
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
 
-    - name: Publish to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,43 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    # Only create releases from the canonical repository
+    if: github.repository == 'Yasas1994/Jaeger'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Generate release notes
+        id: release_notes
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+          # Extract changelog section for this version
+          if [ -f CHANGELOG.md ]; then
+            awk '/^## \['"${VERSION}"'\]/ {found=1; next} /^## \[/ {found=0} found' CHANGELOG.md > /tmp/notes.md || true
+          fi
+
+          if [ ! -s /tmp/notes.md ]; then
+            echo "Automated release for version ${VERSION}." > /tmp/notes.md
+          fi
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          body_path: /tmp/notes.md
+          generate_release_notes: true
+          draft: false
+          prerelease: ${{ contains(github.ref_name, 'a') || contains(github.ref_name, 'b') || contains(github.ref_name, 'rc') }}

--- a/docs/_source/index.md
+++ b/docs/_source/index.md
@@ -1,0 +1,58 @@
+```
+                  .                                                         
+               ,'/ \`.                                                      
+              |\/___\/|                                                     
+              \'\   /`/          ██╗ █████╗ ███████╗ ██████╗ ███████╗██████╗
+               `.\ /,'           ██║██╔══██╗██╔════╝██╔════╝ ██╔════╝██╔══██╗
+                  |              ██║███████║█████╗  ██║  ███╗█████╗  ██████╔╝
+                  |         ██   ██║██╔══██║██╔══╝  ██║   ██║██╔══╝  ██╔══██╗
+                 |=|        ╚█████╔╝██║  ██║███████╗╚██████╔╝███████╗██║  ██║
+            /\  ,|=|.  /\    ╚════╝ ╚═╝  ╚═╝╚══════╝ ╚═════╝ ╚══════╝╚═╝  ╚═╝
+        ,'`.  \/ |=| \/  ,'`.                                                
+      ,'    `.|\ `-' /|,'    `.                                              
+    ,'   .-._ \ `---' / _,-.   `.                                            
+       ,'    `-`-._,-'-'   `.     
+      '  
+```
+
+
+
+Jaeger : an accurate and fast deep-learning tool to detect bacteriophage sequences
+===============
+<p align="center">
+  <a href="https://github.com/Yasas1994/jaeger/blob/main/LICENSE">
+    <img src="https://img.shields.io/github/license/Yasas1994/jaeger" alt="License">
+  </a>
+  <a href="https://github.com/Yasas1994/jaeger/commits/main">
+    <img src="https://img.shields.io/github/last-commit/Yasas1994/jaeger/main?color=8a35da" alt="Last commit">
+  </a>
+  <a href="https://anaconda.org/bioconda/jaeger-bio">
+    <img src="https://img.shields.io/conda/v/bioconda/jaeger-bio" alt="Conda version">
+  </a>
+  <a href="https://anaconda.org/bioconda/jaeger-bio">
+    <img src="https://img.shields.io/conda/dn/bioconda/jaeger-bio" alt="Conda downloads">
+  </a>
+  <a href="https://badge.fury.io/py/jaeger-bio">
+    <img src="https://badge.fury.io/py/jaeger-bio.svg" alt="PyPI version">
+  </a>
+  <a href="https://pepy.tech/project/jaeger-bio">
+    <img src="https://static.pepy.tech/badge/jaeger-bio" alt="Downloads">
+  </a>
+  <a href="https://zenodo.org/doi/10.5281/zenodo.13336194">
+    <img src="https://zenodo.org/badge/379281156.svg" alt="DOI">
+  </a>
+</p>
+
+
+```{toctree}
+:maxdepth 1
+:caption contents
+
+start
+installation
+usage
+train
+utils
+releasing
+
+```

--- a/docs/_source/releasing.md
+++ b/docs/_source/releasing.md
@@ -1,0 +1,284 @@
+# Releasing Jaeger
+
+This guide is for maintainers who need to bump the version, build a new release, and publish it to PyPI and Bioconda.
+
+---
+
+## Versioning scheme
+
+Jaeger uses a calendar-based versioning format:
+
+```
+<major>.<year>.<update>
+```
+
+| Component | Meaning | Example |
+|---|---|---|
+| `major` | Major product version | `1` |
+| `year` | Last two digits of release year | `26` = 2026 |
+| `update` | Incremental update within that year | `1`, `2`, `3` … |
+
+Examples:
+- `1.26.1` — first update of 2026
+- `1.26.5` — fifth update of 2026
+- `2.27.1` — first update of 2027, new major version
+
+---
+
+## Prerequisites
+
+- Commitizen (`cz`) installed: `pip install commitizen`
+- PDM installed: `pip install pdm`
+- Write access to the canonical repository (`Yasas1994/Jaeger`)
+- PyPI Trusted Publishing (OIDC) configured for the repository (see [OIDC setup](#openid-connect-oidc-setup) below)
+- Bioconda bot token (`BIOCONDA_BOT_TOKEN`) configured as a repository secret
+
+---
+
+## Step 1: Bump the version
+
+### Option A — Auto-bump (recommended)
+
+Run the bump script from the repo root. It auto-detects the current version and increments the `update` counter (or resets to `1` if the year changed):
+
+```bash
+.github/scripts/bump-version.sh
+```
+
+### Option B — Explicit version
+
+Set a specific version directly:
+
+```bash
+.github/scripts/bump-version.sh 1 26 5   # sets 1.26.5
+.github/scripts/bump-version.sh 2 27 1   # sets 2.27.1
+```
+
+### What the script updates
+
+The script edits version strings in:
+
+| File | Field |
+|---|---|
+| `pyproject.toml` | `version = "…"` |
+| `.cz.toml` | `version = "…"` |
+| `recipes/jaeger-bio/meta.yaml` | `{% set version = "…" %}` |
+| `singularity/jaeger_singularity.def` | `jaeger-bio==…` |
+| `README.md` | `## Jaeger X.Y.Z …` header |
+| `AGENTS.md` | ``Current version: `X.Y.Z` `` |
+| `docs/_source/usage.md` | Header + `jaeger_X.Y.Z.sif` |
+| `docs/_source/_static/usage.md` | Header + `jaeger_X.Y.Z.sif` |
+
+Review the changes:
+
+```bash
+git diff
+```
+
+---
+
+## Step 2: Commit and tag
+
+Stage the version bumps and commit:
+
+```bash
+git add -A
+git commit -m "chore(release): bump version to $(grep -m1 '^version' pyproject.toml | sed 's/.*"\(.*\)".*/\1/')"
+```
+
+Create an annotated tag:
+
+```bash
+git tag -a v$(grep -m1 '^version' pyproject.toml | sed 's/.*"\(.*\)".*/\1/') -m "Release version X.Y.Z"
+```
+
+Or use Commitizen to handle changelog + tag together:
+
+```bash
+cz bump
+```
+
+This updates `CHANGELOG.md`, bumps `.cz.toml`, and creates the Git tag automatically.
+
+---
+
+## Step 3: Push to trigger CI
+
+Push the commit and tag to the **canonical repository** (`Yasas1994/Jaeger`):
+
+```bash
+git push origin main
+git push origin --tags
+```
+
+> **Important:** The publish and release workflows are gated with `github.repository == 'Yasas1994/Jaeger'`. Pushing to forks (e.g. `MGXlab/Jaeger`) will build artifacts for validation but will **not** publish to PyPI or Bioconda.
+
+---
+
+## Step 4: What happens automatically
+
+Once the tag is pushed, GitHub Actions runs the following workflows in sequence:
+
+### 1. `publish-to-pypi.yaml`
+- **Builds** sdist + wheel via `pdm build`
+- **Publishes to PyPI** (production) — only from `Yasas1994/Jaeger`
+- Uses **Trusted Publishing (OIDC)** — no API tokens needed
+
+### 2. `release.yaml`
+- Creates a **GitHub Release** from the tag
+- Pulls release notes from the matching section in `CHANGELOG.md`
+- Auto-detects pre-releases (`a`, `b`, `rc` in tag name)
+
+### 3. `bioconda-update.yaml`
+- Triggered by the GitHub Release being **published**
+- Downloads the PyPI tarball and computes SHA256
+- Checks out `bioconda/bioconda-recipes`
+- Updates `recipes/jaeger-bio/meta.yaml` (version + SHA256)
+- Pushes a branch and opens a PR to Bioconda
+
+---
+
+## Step 5: Verify the release
+
+### PyPI
+
+Check that the new version appears on:
+
+```
+https://pypi.org/project/jaeger-bio/
+```
+
+Install and test:
+
+```bash
+pip install --upgrade jaeger-bio
+jaeger --version
+```
+
+### Bioconda
+
+Monitor the automated PR at:
+
+```
+https://github.com/bioconda/bioconda-recipes/pulls?q=is%3Apr+jaeger-bio
+```
+
+Once merged, the new version will be available via:
+
+```bash
+conda install -c bioconda jaeger-bio
+```
+
+### GitHub Release
+
+Check the release page:
+
+```
+https://github.com/Yasas1994/Jaeger/releases
+```
+
+---
+
+## OpenID Connect (OIDC) setup
+
+PyPI Trusted Publishing uses OIDC so GitHub Actions can authenticate without storing long-lived API tokens.
+
+### 1. Create a PyPI project (or claim an existing one)
+
+If the project already exists on PyPI, log in as an owner or maintainer:
+
+```
+https://pypi.org/manage/project/jaeger-bio/settings/
+```
+
+### 2. Add a Trusted Publisher
+
+In **Publishing**, click **Add a new pending publisher** and fill:
+
+| Field | Value |
+|---|---|
+| **Publisher type** | GitHub Actions |
+| **Owner** | `Yasas1994` |
+| **Repository name** | `Jaeger` |
+| **Workflow name** | `publish-to-pypi.yaml` |
+| **Environment name** | `pypi` *(optional but recommended)* |
+
+Click **Add**. The publisher is now pending — it becomes active after the first successful publish.
+
+### 3. Add TestPyPI publisher (optional but recommended)
+
+Repeat the same on TestPyPI:
+
+```
+https://test.pypi.org/manage/project/jaeger-bio/settings/
+```
+
+Use environment name `testpypi`.
+
+### 4. How it works in the workflow
+
+The workflow requests a short-lived OIDC token from GitHub:
+
+```yaml
+permissions:
+  id-token: write   # Required for OIDC
+
+environment:
+  name: pypi        # Must match the PyPI environment name
+```
+
+`pypa/gh-action-pypi-publish` exchanges this token for a PyPI upload token automatically. No `PYPI_API_TOKEN` secret is needed.
+
+### 5. Troubleshooting
+
+| Error | Cause | Fix |
+|---|---|---|
+| `trusted publishing exchange failed` | Publisher not configured on PyPI | Add the pending publisher in PyPI settings |
+| `invalid-publisher: invalid token` | Wrong owner/repo/workflow name | Double-check the exact values in PyPI settings |
+| `environment … not found` | `environment:` name mismatch | Ensure the workflow `environment.name` matches PyPI |
+| `permission denied` | Running on a fork | Only the canonical repo (`Yasas1994/Jaeger`) is authorized |
+
+---
+
+## Manual fallback
+
+If any automated step fails, you can trigger it manually:
+
+### Manual PyPI publish
+
+```bash
+pdm build
+# Upload to TestPyPI first
+pdm publish --repository testpypi
+# Then production
+pdm publish
+```
+
+### Manual Bioconda update
+
+Go to **Actions → Bioconda Recipe Update → Run workflow** and enter the version:
+
+```
+version: 1.26.5
+```
+
+This requires the `BIOCONDA_BOT_TOKEN` secret to be configured.
+
+### Manual GitHub Release
+
+Go to **Releases → Draft a new release**, select the tag, and publish.
+
+---
+
+## Repository guard
+
+The following jobs are restricted to the canonical repository:
+
+| Workflow | Job | Guard |
+|---|---|---|
+| `publish-to-pypi.yaml` | `publish-testpypi` | `github.repository == 'Yasas1994/Jaeger'` |
+| `publish-to-pypi.yaml` | `publish-pypi` | `github.repository == 'Yasas1994/Jaeger'` |
+| `release.yaml` | `release` | `github.repository == 'Yasas1994/Jaeger'` |
+| `bioconda-update.yaml` | `update-bioconda` | `github.repository == 'Yasas1994/Jaeger'` |
+
+If you maintain a fork and want it to become the canonical repo, change the guard string in all four workflow files.


### PR DESCRIPTION
This PR adds automated release infrastructure:

- **Renovate Bot** configuration for dependency updates
- **PyPI publishing** workflow (TestPyPI on main pushes, PyPI on tags)
- **GitHub Release** generation on tag push
- **Bioconda recipe auto-update** triggered by releases
- **Version bump script** following `<major>.<year>.<update>` scheme
- **Repository guard** so only `Yasas1994/Jaeger` publishes to PyPI/Bioconda
- **Release documentation** with OIDC setup instructions