### PR TITLE
chore(release): v1.26.3 hotfix

### DIFF
--- a/.cz.toml
+++ b/.cz.toml
@@ -2,5 +2,5 @@
 name = "cz_conventional_commits"
 tag_format = "v$version"
 version_scheme = "pep440"
-version = "1.26.2"
+version = "1.26.3"
 update_changelog_on_bump = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ includes = ["src/jaeger/**/*.py", "src/jaeger/**/*.json", "src/jaeger/**/*.h5", 
 
 [project]
 name = "jaeger-bio"
-version = "1.26.2"
+version = "1.26.3"
 description = "A quick and precise pipeline for detecting phages in sequence assemblies."
 readme = "README.md"
 authors = [

--- a/recipes/jaeger-bio/meta.yaml
+++ b/recipes/jaeger-bio/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "jaeger-bio" %}
-{% set version = "1.26.2" %}
+{% set version = "1.26.3" %}
 
 package:
   name: "{{ name|lower }}"


### PR DESCRIPTION
## Critical Bug Fix Release

This release fixes severe bugs present in v1.26.2:

### Fixes included (already on main)
- **Keras 3 compatibility**: `self.input_dtype` → `self._input_dtype`, `mask` parameter in pooling layers
- **Loss function crash**: `SupervisedContrastiveLoss` now handles both sparse and one-hot labels
- **Optional dependency**: `icecream` import made optional (was breaking CI/production installs)
- **CLI rename**: `jaeger test` → `jaeger health` with comprehensive diagnostics
- **Missing test data**: Added test data files to git tracking
- **Build fix**: SavedModel graph directory properly included in pdm-backend builds

### Post-release actions
- [ ] Yank v1.26.2 from PyPI
- [ ] Add deprecation notice to GitHub Release v1.26.2