### PR TITLE
feat: linear genome plots and prophage prediction in new pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,4 @@ dist
 *fasta
 !src/jaeger/data/test/*.fasta
 test_log/*
-data/*
+data/*memory/

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ dist
 !src/jaeger/data/test/*.fasta
 test_log/*
 data/*memory/
+memory/
+memory_management.md

--- a/docs/_source/_static/usage.md
+++ b/docs/_source/_static/usage.md
@@ -111,7 +111,7 @@ output_dir/
 └── <sample_name>_prophages/
     ├── prophages_jaeger.tsv     # Prophage coordinates
     └── plots/
-        └── *.pdf                # Circular genome visualizations
+        └── *.pdf                # Genome visualizations (circular and/or linear)
 ```
 
 ---
@@ -174,7 +174,27 @@ Set minimum contig length for prophage scanning:
 jaeger predict -p -i genome.fna -o output_dir --lc 100000
 ```
 
-The `plots/` directory contains circular genome visualizations with prophage regions highlighted.
+The `plots/` directory contains genome visualizations with prophage regions highlighted. By default, circular plots are generated. Use `--plot-type` to select linear plots, both, or none.
+
+### Plot types
+
+| `--plot-type` | Description |
+|---------------|-------------|
+| `circular` | Circular genome map (default) |
+| `linear` | Horizontal 4-panel linear plot |
+| `both` | Generate both circular and linear plots |
+| `none` | Skip plot generation (report only) |
+
+```bash
+# Generate linear plots instead of circular
+jaeger predict -p -i genome.fna -o output_dir --plot-type linear
+
+# Generate both circular and linear plots
+jaeger predict -p -i genome.fna -o output_dir --plot-type both
+
+# Skip plots, generate TSV report only
+jaeger predict -p -i genome.fna -o output_dir --plot-type none
+```
 
 ---
 
@@ -219,6 +239,8 @@ Options:
                            (0-4)  [default: 1.5]
   --lc INTEGER             Minimum contig length for prophage extraction
                            [default: 500000]
+  --plot-type [circular|linear|both|none]
+                           Prophage plot type  [default: circular]
   --rc FLOAT               Minimum reliability score required to accept
                            predictions  [default: 0.1]
   --pc INTEGER             Minimum phage score required to accept predictions

--- a/docs/_source/index.md
+++ b/docs/_source/index.md
@@ -34,6 +34,7 @@ Jaeger : an accurate and fast deep-learning tool to detect bacteriophage sequenc
 start
 installation
 usage
+optimizations
 train
 utils
 releasing

--- a/docs/_source/optimizations.md
+++ b/docs/_source/optimizations.md
@@ -1,0 +1,356 @@
+# Performance optimizations
+
+Jaeger provides several optional inference backends and precision modes.
+This page explains how to use them, ordered from **least effort** to **most effort**.
+
+All commands below assume Jaeger is installed with GPU support
+(`pip install jaeger-bio[gpu]` or equivalent).
+
+---
+
+## Quick comparison
+
+| Optimization | Effort | Speedup | Model size | Best for |
+|--------------|--------|---------|------------|----------|
+| [Mixed precision](#1-mixed-precision) | One flag | 1–1.3× | No change | Any GPU with FP16/BF16 support |
+| [XLA JIT](#2-xla-jit-compilation) | One flag | 1.5–3× after warmup | No change | Large datasets with repeated shapes |
+| [ONNX Runtime](#3-onnx-runtime) | One conversion | 1.5–2× | No change | Reliable cross-platform GPU inference |
+| [TFLite quantization](#4-tflite-quantization) | One conversion | Similar | ~3.5× smaller | Edge / mobile / low-storage deployments |
+| [ONNX INT8](#5-onnx-int8-quantization) | Conversion + quantization | 1–1.5× | ~2.5× smaller | Smallest GPU-deployable model |
+| [TensorRT (TF-TRT)](#6-tensorrt-tf-trt) | Custom TF build | 2–5× | No change | Maximum GPU performance in specialized containers |
+
+---
+
+## 1. Mixed precision
+
+**Effort:** lowest — add one flag to `jaeger predict`.
+
+Run inference with FP16 or BF16 instead of FP32. This reduces memory
+bandwidth and can speed up math-bound layers on modern NVIDIA GPUs
+(Compute Capability ≥ 7.0 for FP16, ≥ 8.0 for BF16).
+
+```bash
+# FP16 (widely supported)
+jaeger predict -i contigs.fasta -o output_dir --precision fp16
+
+# BF16 (Ampere/Ada and newer)
+jaeger predict -i contigs.fasta -o output_dir --precision bf16
+```
+
+### When to use
+
+- You want a quick, risk-free speedup with no preprocessing.
+- Your GPU supports FP16/BF16 tensor cores.
+- You are not memory-limited (model size stays the same).
+
+### Caveats
+
+- Very small batches may not see a speedup because the overhead of
+casting can dominate.
+- Some older GPUs (pre-Volta) have reduced FP16 throughput.
+
+---
+
+## 2. XLA JIT compilation
+
+**Effort:** low — add one flag to `jaeger predict`.
+
+XLA (Accelerated Linear Algebra) JIT-compiles the TensorFlow graph
+for each unique input shape. After the first compilation, repeated
+shapes run significantly faster.
+
+```bash
+jaeger predict -i contigs.fasta -o output_dir --xla
+```
+
+You can combine XLA with mixed precision:
+
+```bash
+jaeger predict -i contigs.fasta -o output_dir --xla --precision fp16
+```
+
+### When to use
+
+- Large datasets where many windows have the same length.
+- Benchmarking / repeated inference on the same file.
+
+### Caveats
+
+- The first batch for each unique shape is slow (~10–30 s compilation).
+- For small or highly variable-length datasets, compilation overhead
+can exceed the speedup.
+
+---
+
+## 3. ONNX Runtime
+
+**Effort:** medium — convert the model once, then run with `--onnx`.
+
+ONNX Runtime decouples Jaeger from TensorFlow's execution stack and
+supports multiple GPU providers (TensorRT, CUDA, CPU) without requiring
+TensorFlow to be built with those backends.
+
+### 3.1 Install dependencies
+
+```bash
+pip install onnxruntime-gpu tf2onnx sympy onnx
+```
+
+**Important:** ONNX Runtime 1.26 requires **TensorRT 10**.
+If you have TensorRT 11 installed, downgrade:
+
+```bash
+pip install tensorrt==10.16.1.11
+```
+
+### 3.2 Convert the model
+
+```bash
+jaeger utils convert-graph \
+  -m jaeger_57341_1.5M_fragment \
+  -o ./optimized \
+  --mode onnx
+```
+
+This creates:
+
+```
+optimized/
+└── jaeger_57341_1.5M_fragment_onnx/
+    ├── jaeger_57341_1.5M_fragment.onnx
+    ├── jaeger_57341_1.5M_fragment_classes.yaml
+    └── jaeger_57341_1.5M_fragment_project.yaml
+```
+
+### 3.3 Run inference
+
+```bash
+jaeger predict -i contigs.fasta -o output_dir \
+  -m jaeger_57341_1.5M_fragment \
+  --onnx
+```
+
+### Provider selection
+
+`ONNXEngine` automatically picks the best available provider:
+
+1. `TensorrtExecutionProvider` (NVIDIA GPUs)
+2. `CUDAExecutionProvider`
+3. `CPUExecutionProvider`
+
+The first inference with TensorRT is slow because it builds the
+TensorRT engine; subsequent runs with the same shape reuse the cached
+engine.
+
+### When to use
+
+- You want 1.5–2× speedup on NVIDIA GPUs without custom TensorFlow builds.
+- You need a portable model that can also run on CPU.
+
+---
+
+## 4. TFLite quantization
+
+**Effort:** medium — quantize the model once, then run with `--quantized`.
+
+TFLite is primarily useful for reducing model size for edge or mobile
+deployment. Speed on desktop GPUs is usually comparable to the original
+SavedModel.
+
+### 4.1 Quantize the model
+
+```bash
+# Dynamic range quantization (recommended)
+jaeger utils quantize \
+  -m jaeger_57341_1.5M_fragment \
+  -o ./quantized \
+  --mode dynamic
+
+# Float16 weights
+jaeger utils quantize \
+  -m jaeger_57341_1.5M_fragment \
+  -o ./quantized \
+  --mode float16
+
+# Full INT8 (experimental)
+jaeger utils quantize \
+  -m jaeger_57341_1.5M_fragment \
+  -o ./quantized \
+  --mode full_int8
+```
+
+This creates:
+
+```
+quantized/
+└── jaeger_57341_1.5M_fragment_dynamic/
+    ├── jaeger_57341_1.5M_fragment_dynamic.tflite
+    └── ... metadata ...
+```
+
+### 4.2 Run inference
+
+```bash
+jaeger predict -i contigs.fasta -o output_dir \
+  -m jaeger_57341_1.5M_fragment \
+  --quantized dynamic
+```
+
+### When to use
+
+- Model size matters more than speed (e.g., ~6 MB → ~1.6 MB with dynamic).
+- Edge devices, mobile apps, or low-bandwidth deployments.
+
+### Caveats
+
+- `full_int8` is experimental and can reduce accuracy on real data;
+`dynamic` is recommended.
+- Desktop GPU speed is usually not faster than the original model.
+
+---
+
+## 5. ONNX INT8 quantization
+
+**Effort:** higher — convert to ONNX and then apply static INT8
+quantization. Gives the smallest GPU-runnable model.
+
+### 5.1 Install dependencies
+
+Same as [ONNX Runtime](#31-install-dependencies):
+
+```bash
+pip install onnxruntime-gpu tf2onnx sympy onnx
+```
+
+### 5.2 Convert and quantize
+
+```bash
+jaeger utils convert-graph \
+  -m jaeger_57341_1.5M_fragment \
+  -o ./optimized \
+  --mode onnx \
+  --int8
+```
+
+This creates:
+
+```
+optimized/
+└── jaeger_57341_1.5M_fragment_onnx_int8/
+    ├── jaeger_57341_1.5M_fragment_int8.onnx   # quantized
+    ├── jaeger_57341_1.5M_fragment.onnx        # original FP32
+    └── ... metadata ...
+```
+
+### 5.3 Run inference
+
+```bash
+jaeger predict -i contigs.fasta -o output_dir \
+  -m jaeger_57341_1.5M_fragment \
+  --onnx --int8
+```
+
+### When to use
+
+- You need the smallest possible model that still runs on GPU
+(~6 MB → ~2.4 MB).
+- You want faster-than-SavedModel inference without a custom TF build.
+
+### Caveats
+
+- INT8 ONNX models use the **CUDA** execution provider, not TensorRT,
+because TensorRT's ONNX parser has strict requirements for quantized
+subgraphs.
+- Calibration is performed with synthetic one-hot codon tensors.
+Accuracy is usually very close to FP32, but you should validate on
+your target data.
+
+---
+
+## 6. TensorRT (TF-TRT)
+
+**Effort:** highest — requires TensorFlow built with TensorRT support.
+
+Standard pip-installed TensorFlow does **not** include TensorRT.
+This path is only practical if you use NVIDIA's NGC containers or
+build TensorFlow from source.
+
+### 6.1 Use an NGC container
+
+```bash
+docker run --gpus all -it nvcr.io/nvidia/tensorflow:24.10-tf2-py3
+```
+
+Inside the container, install Jaeger and run:
+
+```bash
+jaeger utils convert-graph \
+  -m jaeger_57341_1.5M_fragment \
+  -o ./optimized \
+  --mode tensorrt
+```
+
+### 6.2 Easier alternative
+
+For most users, [ONNX Runtime with TensorRT](#3-onnx-runtime) is the
+better path: it does not require a custom TensorFlow build and gives
+most of the speedup.
+
+### When to use
+
+- Maximum GPU performance is required.
+- You already run workloads in NVIDIA NGC containers.
+
+---
+
+## Environment configuration
+
+### For ONNX Runtime + TensorRT
+
+If you see errors like:
+
+```
+libnvinfer.so.10: cannot open shared object file
+libcudnn.so.9: cannot open shared object file
+```
+
+Install the matching pip packages:
+
+```bash
+# Required for ONNX Runtime 1.26
+pip install tensorrt==10.16.1.11
+pip install nvidia-cudnn-cu12  # provides libcudnn.so.9
+```
+
+Jaeger's `ONNXEngine` automatically preloads these libraries via
+`ctypes` so you usually do **not** need to set `LD_LIBRARY_PATH`.
+If you still have issues, you can export the library paths manually:
+
+```bash
+export LD_LIBRARY_PATH="$(python -c 'import site; print(site.getsitepackages()[0])')/tensorrt_libs:$(python -c 'import site; print(site.getsitepackages()[0])')/nvidia/cudnn/lib:${LD_LIBRARY_PATH}"
+```
+
+### Verify providers
+
+```python
+python -c "import onnxruntime as ort; print(ort.get_available_providers())"
+```
+
+Expected output on a working NVIDIA system:
+
+```python
+['TensorrtExecutionProvider', 'CUDAExecutionProvider', 'CPUExecutionProvider']
+```
+
+---
+
+## Choosing an optimization
+
+| Situation | Recommended option |
+|-----------|--------------------|
+| Just want a quick speedup | `--precision fp16` |
+| Large dataset, repeated shapes | `--xla --precision fp16` |
+| Reliable GPU speedup without custom builds | Convert to ONNX, then `--onnx` |
+| Need smallest model on GPU | Convert to ONNX INT8, then `--onnx --int8` |
+| Need smallest model for edge/mobile | `jaeger utils quantize --mode dynamic` |
+| Maximum performance in NGC containers | `jaeger utils convert-graph --mode tensorrt` |

--- a/docs/_source/usage.md
+++ b/docs/_source/usage.md
@@ -113,7 +113,7 @@ output_dir/
 └── <sample_name>_prophages/
     ├── prophages_jaeger.tsv     # Prophage coordinates
     └── plots/
-        └── *.pdf                # Circular genome visualizations
+        └── *.pdf                # Genome visualizations (circular and/or linear)
 ```
 
 ---
@@ -176,7 +176,27 @@ Set minimum contig length for prophage scanning:
 jaeger predict -p -i genome.fna -o output_dir --lc 100000
 ```
 
-The `plots/` directory contains circular genome visualizations with prophage regions highlighted.
+The `plots/` directory contains genome visualizations with prophage regions highlighted. By default, circular plots are generated. Use `--plot-type` to select linear plots, both, or none.
+
+### Plot types
+
+| `--plot-type` | Description |
+|---------------|-------------|
+| `circular` | Circular genome map (default) |
+| `linear` | Horizontal 4-panel linear plot |
+| `both` | Generate both circular and linear plots |
+| `none` | Skip plot generation (report only) |
+
+```bash
+# Generate linear plots instead of circular
+jaeger predict -p -i genome.fna -o output_dir --plot-type linear
+
+# Generate both circular and linear plots
+jaeger predict -p -i genome.fna -o output_dir --plot-type both
+
+# Skip plots, generate TSV report only
+jaeger predict -p -i genome.fna -o output_dir --plot-type none
+```
 
 ---
 
@@ -221,6 +241,8 @@ Options:
                            (0-4)  [default: 1.5]
   --lc INTEGER             Minimum contig length for prophage extraction
                            [default: 500000]
+  --plot-type [circular|linear|both|none]
+                           Prophage plot type  [default: circular]
   --rc FLOAT               Minimum reliability score required to accept
                            predictions  [default: 0.1]
   --pc INTEGER             Minimum phage score required to accept predictions

--- a/docs/_source/usage.md
+++ b/docs/_source/usage.md
@@ -2,6 +2,8 @@
 
 This guide covers the main prediction workflow, output interpretation, prophage extraction, and available utility commands.
 
+For inference speedups and model quantization, see the [Performance optimizations](optimizations.md) page.
+
 ---
 
 ## Table of contents

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,3 +61,9 @@ gpu = [
 cpu = [
     "tensorflow >=2.18, <2.19",
 ]
+onnx = [
+    "onnxruntime-gpu >=1.26",
+    "tf2onnx >=1.17",
+    "sympy >=1.13",
+    "onnx >=1.16",
+]

--- a/recipes/jaeger-bio/meta.yaml
+++ b/recipes/jaeger-bio/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name | replace('-', '_') }}-{{ version }}.tar.gz"
-  sha256: b890227e03f123d5bc3d8f29269f5256079fe4dfd87ec22d85da9206e18e46eb
+  sha256: 4cd0bdf87f4f52731d46508d7cd4852dd9dc6b2eab1e75dd14ed423dab333a07
 
 build:
   number: 0
@@ -51,6 +51,7 @@ test:
 
   commands:
     - jaeger --help
+    - jaeger predict --help
 
 about:
   home: "https://github.com/Yasas1994/Jaeger"

--- a/recipes/jaeger-bio/meta.yaml
+++ b/recipes/jaeger-bio/meta.yaml
@@ -7,6 +7,7 @@ package:
 
 source:
   url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name | replace('-', '_') }}-{{ version }}.tar.gz"
+  # NOTE: update sha256 after releasing to PyPI
   sha256: 4cd0bdf87f4f52731d46508d7cd4852dd9dc6b2eab1e75dd14ed423dab333a07
 
 build:
@@ -42,6 +43,11 @@ requirements:
     - pyyaml >=6.0.2
     - jinja2 >=3.1
     - pydustmasker >=1.0.3
+    # Optional: for ONNX inference and quantization
+    # - onnxruntime-gpu >=1.26
+    # - tf2onnx >=1.17
+    # - sympy >=1.13
+    # - onnx >=1.16
 
 test:
   imports:

--- a/src/jaeger/cli.py
+++ b/src/jaeger/cli.py
@@ -186,6 +186,11 @@ def health(**kwargs):
     default="fp32",
     help="GPU inference precision: fp32 (default), fp16, or bf16. fp16/bf16 reduce memory and may speed up inference on compatible GPUs.",
 )
+@click.option(
+    "--xla",
+    is_flag=True,
+    help="Enable XLA JIT compilation for inference. May provide 2-3x speedup on GPU after initial compilation overhead.",
+)
 def predict(**kwargs):
     """
     Runs Jaeger on a dataset

--- a/src/jaeger/cli.py
+++ b/src/jaeger/cli.py
@@ -197,6 +197,11 @@ def health(**kwargs):
     is_flag=True,
     help="Use ONNX Runtime for inference. Requires converting the model first with 'jaeger utils convert-graph --mode onnx'.",
 )
+@click.option(
+    "--int8",
+    is_flag=True,
+    help="Use INT8 quantized ONNX model (use with --onnx). Requires 'jaeger utils convert-graph --mode onnx --int8'.",
+)
 def predict(**kwargs):
     """
     Runs Jaeger on a dataset
@@ -973,6 +978,7 @@ def quantize_cmd(**kwargs):
 
             jaeger utils convert-graph -m default -o ./optimized --mode xla
             jaeger utils convert-graph -m default -o ./optimized --mode onnx
+            jaeger utils convert-graph -m default -o ./optimized --mode onnx --int8
         """,
 )
 @click.option(
@@ -996,15 +1002,20 @@ def quantize_cmd(**kwargs):
     help="Conversion mode",
 )
 @click.option(
+    "--int8",
+    is_flag=True,
+    help="Apply static INT8 quantization (ONNX mode only)",
+)
+@click.option(
     "-v",
     "--verbose",
     count=True,
     help="Verbosity level",
     default=1,
 )
-def convert_graph_cmd(model, output, mode, verbose):
+def convert_graph_cmd(model, output, mode, int8, verbose):
     """Convert a Jaeger SavedModel to an optimized inference graph."""
-    convert_graph(model, output, mode, verbose)
+    convert_graph(model, output, mode, verbose, int8=int8)
 
 
 @click.group(context_settings=dict(help_option_names=["-h", "--help"]))

--- a/src/jaeger/cli.py
+++ b/src/jaeger/cli.py
@@ -120,6 +120,12 @@ def health(**kwargs):
     help="Minimum contig length for prophage extraction",
 )
 @click.option(
+    "--plot-type",
+    type=click.Choice(["circular", "linear", "both", "none"]),
+    default="circular",
+    help="Prophage plot type: circular (default), linear, both, or none",
+)
+@click.option(
     "--rc",
     type=float,
     default=0.1,

--- a/src/jaeger/cli.py
+++ b/src/jaeger/cli.py
@@ -178,7 +178,13 @@ def health(**kwargs):
 @click.option(
     "--quantized",
     type=click.Choice(["dynamic", "float16", "full_int8"]),
-    help="Use quantized model for inference (dynamic|float16|full_int8)",
+    help="Use quantized TFLite model for inference (dynamic|float16|full_int8)",
+)
+@click.option(
+    "--precision",
+    type=click.Choice(["fp32", "fp16", "bf16"]),
+    default="fp32",
+    help="GPU inference precision: fp32 (default), fp16, or bf16. fp16/bf16 reduce memory and may speed up inference on compatible GPUs.",
 )
 def predict(**kwargs):
     """

--- a/src/jaeger/cli.py
+++ b/src/jaeger/cli.py
@@ -18,6 +18,7 @@ from importlib.metadata import version
 from importlib.resources import files
 from jaeger.utils.misc import json_to_dict, add_data_to_json, AvailableModels
 import warnings
+from jaeger.commands.quantize import quantize_model
 
 warnings.filterwarnings("ignore")
 
@@ -174,6 +175,11 @@ def health(**kwargs):
     default=1,
 )
 @click.option("-f", "--overwrite", is_flag=True, help="Overwrite existing files")
+@click.option(
+    "--quantized",
+    type=click.Choice(["dynamic", "float16", "full_int8"]),
+    help="Use quantized model for inference (dynamic|float16|full_int8)",
+)
 def predict(**kwargs):
     """
     Runs Jaeger on a dataset
@@ -892,6 +898,50 @@ def stats(**kwargs):
 
     stats_core(**kwargs)
     pass
+
+
+@utils.command(
+    context_settings=dict(ignore_unknown_options=True, show_default=True),
+    help="""
+            Quantize a Jaeger model for faster inference
+
+            usage
+            -----
+
+            jaeger utils quantize -m default -o ./quantized_models
+            jaeger utils quantize -m jaeger_57341_1.5M_fragment -o ./quantized --mode float16
+        """,
+)
+@click.option(
+    "-m",
+    "--model",
+    type=str,
+    required=True,
+    help="Model name to quantize",
+)
+@click.option(
+    "-o",
+    "--output",
+    type=click.Path(path_type=Path),
+    required=True,
+    help="Output directory for the quantized model",
+)
+@click.option(
+    "--mode",
+    type=click.Choice(["dynamic", "float16", "full_int8"]),
+    default="dynamic",
+    help="Quantization mode",
+)
+@click.option(
+    "-v",
+    "--verbose",
+    count=True,
+    help="Verbosity level",
+    default=1,
+)
+def quantize_cmd(**kwargs):
+    """Quantize a Jaeger model"""
+    quantize_model(**kwargs)
 
 
 @click.group(context_settings=dict(help_option_names=["-h", "--help"]))

--- a/src/jaeger/cli.py
+++ b/src/jaeger/cli.py
@@ -19,6 +19,7 @@ from importlib.resources import files
 from jaeger.utils.misc import json_to_dict, add_data_to_json, AvailableModels
 import warnings
 from jaeger.commands.quantize import quantize_model
+from jaeger.commands.convert_graph import convert_graph
 
 warnings.filterwarnings("ignore")
 
@@ -190,6 +191,11 @@ def health(**kwargs):
     "--xla",
     is_flag=True,
     help="Enable XLA JIT compilation for inference. May provide 2-3x speedup on GPU after initial compilation overhead.",
+)
+@click.option(
+    "--onnx",
+    is_flag=True,
+    help="Use ONNX Runtime for inference. Requires converting the model first with 'jaeger utils convert-graph --mode onnx'.",
 )
 def predict(**kwargs):
     """
@@ -953,6 +959,52 @@ def stats(**kwargs):
 def quantize_cmd(**kwargs):
     """Quantize a Jaeger model"""
     quantize_model(**kwargs)
+
+
+@utils.command(
+    context_settings=dict(ignore_unknown_options=True, show_default=True),
+    help="""
+            Convert a Jaeger SavedModel to an optimized inference graph.
+
+            Supports XLA, TFLite, ONNX, and TensorRT backends.
+
+            usage
+            -----
+
+            jaeger utils convert-graph -m default -o ./optimized --mode xla
+            jaeger utils convert-graph -m default -o ./optimized --mode onnx
+        """,
+)
+@click.option(
+    "-m",
+    "--model",
+    type=str,
+    required=True,
+    help="Model name to convert",
+)
+@click.option(
+    "-o",
+    "--output",
+    type=click.Path(path_type=Path),
+    required=True,
+    help="Output directory for the converted model",
+)
+@click.option(
+    "--mode",
+    type=click.Choice(["xla", "tflite", "onnx", "tensorrt"]),
+    default="xla",
+    help="Conversion mode",
+)
+@click.option(
+    "-v",
+    "--verbose",
+    count=True,
+    help="Verbosity level",
+    default=1,
+)
+def convert_graph_cmd(model, output, mode, verbose):
+    """Convert a Jaeger SavedModel to an optimized inference graph."""
+    convert_graph(model, output, mode, verbose)
 
 
 @click.group(context_settings=dict(help_option_names=["-h", "--help"]))

--- a/src/jaeger/commands/convert_graph.py
+++ b/src/jaeger/commands/convert_graph.py
@@ -25,7 +25,9 @@ import click
 import numpy as np
 import tensorflow as tf
 import yaml
-from tensorflow.python.framework.convert_to_constants import convert_variables_to_constants_v2
+from tensorflow.python.framework.convert_to_constants import (
+    convert_variables_to_constants_v2,
+)
 
 from jaeger.utils.misc import AvailableModels
 
@@ -93,7 +95,9 @@ def convert_graph(
     log.info(f"Conversion complete. Output: {converted_dir}")
 
 
-def _convert_xla(graph_dir: Path, output_dir: Path, model_name: str, log: logging.Logger):
+def _convert_xla(
+    graph_dir: Path, output_dir: Path, model_name: str, log: logging.Logger
+):
     """Convert SavedModel to XLA-optimized SavedModel.
 
     XLA (Accelerated Linear Algebra) uses JIT compilation to fuse operations
@@ -126,7 +130,9 @@ def _convert_xla(graph_dir: Path, output_dir: Path, model_name: str, log: loggin
 
         @tf.function(
             input_signature=[
-                tf.TensorSpec(shape=(None, 6, None, 64), dtype=tf.float32, name="inputs")
+                tf.TensorSpec(
+                    shape=(None, 6, None, 64), dtype=tf.float32, name="inputs"
+                )
             ]
         )
         def serving_default(self, inputs):
@@ -137,7 +143,9 @@ def _convert_xla(graph_dir: Path, output_dir: Path, model_name: str, log: loggin
     log.info("XLA model saved")
 
 
-def _convert_tflite(graph_dir: Path, output_dir: Path, model_name: str, log: logging.Logger):
+def _convert_tflite(
+    graph_dir: Path, output_dir: Path, model_name: str, log: logging.Logger
+):
     """Convert SavedModel to TFLite (same as quantize but without quantization)."""
     log.info("Loading SavedModel for TFLite conversion...")
     loaded = tf.saved_model.load(str(graph_dir))
@@ -179,7 +187,7 @@ def _convert_onnx(
             on TensorRT's INT8 tensor cores. Requires a calibration step.
     """
     try:
-        import tf2onnx
+        import tf2onnx  # noqa: F401
     except ImportError:
         log.error(
             "tf2onnx is not installed. Install it with:\n"
@@ -193,13 +201,21 @@ def _convert_onnx(
 
     # Use tf2onnx to convert
     import subprocess
+
     cmd = [
-        sys.executable, "-m", "tf2onnx.convert",
-        "--saved-model", str(graph_dir),
-        "--output", str(onnx_path),
-        "--opset", "13",
-        "--signature", "serving_default",
-        "--tag", "serve",
+        sys.executable,
+        "-m",
+        "tf2onnx.convert",
+        "--saved-model",
+        str(graph_dir),
+        "--output",
+        str(onnx_path),
+        "--opset",
+        "13",
+        "--signature",
+        "serving_default",
+        "--tag",
+        "serve",
     ]
 
     result = subprocess.run(cmd, capture_output=True, text=True)
@@ -207,11 +223,14 @@ def _convert_onnx(
         log.error(f"ONNX conversion failed:\n{result.stderr}")
         sys.exit(1)
 
-    log.info(f"Saved ONNX model: {onnx_path} ({onnx_path.stat().st_size / 1024 / 1024:.1f} MB)")
+    log.info(
+        f"Saved ONNX model: {onnx_path} ({onnx_path.stat().st_size / 1024 / 1024:.1f} MB)"
+    )
 
     # Verify the model
     try:
         import onnx
+
         onnx_model = onnx.load(str(onnx_path))
         onnx.checker.check_model(onnx_model)
         log.info("ONNX model validation passed")
@@ -376,7 +395,9 @@ def _build_calibration_inputs(
         _tmp_info = {"graph": graph_dir, "classes": None, "project": None}
         _tmp_infer = InferModel.__new__(InferModel)
         _tmp_infer.class_map = {}
-        _tmp_infer.string_processor_config = _tmp_infer._load_string_processor_config(None)
+        _tmp_infer.string_processor_config = _tmp_infer._load_string_processor_config(
+            None
+        )
 
         # We need the project YAML to get the real config. Try to find it next
         # to the SavedModel directory.
@@ -421,9 +442,6 @@ def _build_calibration_inputs(
         dataset = dataset.map(process_fn, num_parallel_calls=tf.data.AUTOTUNE)
         dataset = dataset.batch(1).prefetch(tf.data.AUTOTUNE)
 
-        # Run the original SavedModel to get calibrated inputs
-        loaded = tf.saved_model.load(str(graph_dir))
-        infer = loaded.signatures["serving_default"]
         input_type = spc.get("input_type", "translated")
 
         for inputs_dict in dataset.take(num_samples):
@@ -477,7 +495,9 @@ def _synthetic_one_hot_samples(
     return samples
 
 
-def _convert_tensorrt(graph_dir: Path, output_dir: Path, model_name: str, log: logging.Logger):
+def _convert_tensorrt(
+    graph_dir: Path, output_dir: Path, model_name: str, log: logging.Logger
+):
     """Convert SavedModel to TensorRT-optimized SavedModel.
 
     Requires TensorFlow built with TensorRT support. Most pip-installed

--- a/src/jaeger/commands/convert_graph.py
+++ b/src/jaeger/commands/convert_graph.py
@@ -10,6 +10,7 @@ Usage:
     jaeger utils convert-graph -m default -o ./optimized --mode xla
     jaeger utils convert-graph -m default -o ./optimized --mode tflite
     jaeger utils convert-graph -m default -o ./optimized --mode onnx
+    jaeger utils convert-graph -m default -o ./optimized --mode onnx --int8
     jaeger utils convert-graph -m default -o ./optimized --mode tensorrt
 """
 
@@ -31,7 +32,13 @@ from jaeger.utils.misc import AvailableModels
 logger = logging.getLogger("Jaeger")
 
 
-def convert_graph(model: str, output: Path, mode: str, verbose: int):
+def convert_graph(
+    model: str,
+    output: Path,
+    mode: str,
+    verbose: int,
+    int8: bool = False,
+):
     """Core graph conversion logic (non-CLI)."""
     log = logging.getLogger("Jaeger")
     log.info(f"Converting model '{model}' with mode '{mode}'")
@@ -47,7 +54,8 @@ def convert_graph(model: str, output: Path, mode: str, verbose: int):
     output.mkdir(parents=True, exist_ok=True)
 
     # Create output subdirectory
-    converted_dir = output / f"{model}_{mode}"
+    suffix = "_int8" if (mode == "onnx" and int8) else ""
+    converted_dir = output / f"{model}_{mode}{suffix}"
     if converted_dir.exists():
         shutil.rmtree(converted_dir)
     converted_dir.mkdir(parents=True)
@@ -65,7 +73,7 @@ def convert_graph(model: str, output: Path, mode: str, verbose: int):
     elif mode == "tflite":
         _convert_tflite(graph_dir, converted_dir, model, log)
     elif mode == "onnx":
-        _convert_onnx(graph_dir, converted_dir, model, log)
+        _convert_onnx(graph_dir, converted_dir, model, log, int8=int8)
     elif mode == "tensorrt":
         _convert_tensorrt(graph_dir, converted_dir, model, log)
     else:
@@ -76,6 +84,7 @@ def convert_graph(model: str, output: Path, mode: str, verbose: int):
     info = {
         "original_graph": str(graph_dir),
         "conversion_mode": mode,
+        "int8_quantization": bool(int8) if mode == "onnx" else None,
         "output_dir": str(converted_dir),
     }
     info_path = converted_dir / "conversion_info.yaml"
@@ -148,7 +157,13 @@ def _convert_tflite(graph_dir: Path, output_dir: Path, model_name: str, log: log
     log.info(f"Saved TFLite model: {tflite_path} ({len(tflite_model) / 1024:.1f} KB)")
 
 
-def _convert_onnx(graph_dir: Path, output_dir: Path, model_name: str, log: logging.Logger):
+def _convert_onnx(
+    graph_dir: Path,
+    output_dir: Path,
+    model_name: str,
+    log: logging.Logger,
+    int8: bool = False,
+):
     """Convert SavedModel to ONNX format.
 
     ONNX models can be run with ONNX Runtime, which supports multiple
@@ -157,6 +172,11 @@ def _convert_onnx(graph_dir: Path, output_dir: Path, model_name: str, log: loggi
 
     This is the recommended approach for TensorRT acceleration when
     using pip-installed TensorFlow.
+
+    Args:
+        int8: If True, apply static INT8 quantization using ONNX Runtime's
+            quantization tools. This produces a smaller model that can run
+            on TensorRT's INT8 tensor cores. Requires a calibration step.
     """
     try:
         import tf2onnx
@@ -197,6 +217,264 @@ def _convert_onnx(graph_dir: Path, output_dir: Path, model_name: str, log: loggi
         log.info("ONNX model validation passed")
     except Exception as e:
         log.warning(f"ONNX validation warning: {e}")
+
+    if int8:
+        _quantize_onnx_int8(onnx_path, graph_dir, output_dir, model_name, log)
+
+
+def _quantize_onnx_int8(
+    onnx_path: Path,
+    graph_dir: Path,
+    output_dir: Path,
+    model_name: str,
+    log: logging.Logger,
+):
+    """Apply static INT8 quantization to an ONNX model.
+
+    Uses ONNX Runtime's quantization tools with a calibration dataset
+    derived from real DNA sequences. The quantized model is saved in the
+    output directory as ``{model_name}_int8.onnx``.
+    """
+    try:
+        from onnxruntime.quantization import (
+            CalibrationDataReader,
+            QuantFormat,
+            QuantType,
+            quantize_static,
+        )
+    except ImportError as e:
+        log.error(
+            "ONNX Runtime quantization tools are not available. "
+            f"Install with: pip install onnxruntime-gpu sympy\n{e}"
+        )
+        sys.exit(1)
+
+    import onnx
+
+    log.info("Preparing ONNX model for INT8 quantization...")
+
+    # Run ONNX shape inference first. This is required for both quantization
+    # and for TensorRT/CUDA providers to resolve tensor shapes.
+    try:
+        inferred_path = onnx_path.with_suffix(".inferred.onnx")
+        onnx_model = onnx.load(str(onnx_path))
+        inferred_model = onnx.shape_inference.infer_shapes(onnx_model)
+        onnx.save(inferred_model, str(inferred_path))
+        input_model_path = str(inferred_path)
+        preprocessed_path = inferred_path
+    except Exception as e:
+        log.warning(f"ONNX shape inference failed, using original model: {e}")
+        input_model_path = str(onnx_path)
+        preprocessed_path = None
+
+    # Determine input shape from the model
+    onnx_model = onnx.load(input_model_path)
+    input_tensor = onnx_model.graph.input[0]
+    input_shape = [dim.dim_value for dim in input_tensor.type.tensor_type.shape.dim]
+    # Replace dynamic axes with representative values
+    batch = input_shape[0] if input_shape[0] > 0 else 1
+    frames = input_shape[1] if input_shape[1] > 0 else 6
+    seq_len = input_shape[2] if input_shape[2] > 0 else 500
+    depth = input_shape[3] if len(input_shape) > 3 and input_shape[3] > 0 else 64
+    input_name = input_tensor.name
+
+    log.info(
+        f"Calibration input shape: ({batch}, {frames}, {seq_len}, {depth}); "
+        f"name={input_name}"
+    )
+
+    # Build a calibration dataset from real DNA fragments so the INT8
+    # ranges reflect the actual input distribution.
+    calibration_inputs = _build_calibration_inputs(
+        graph_dir=graph_dir,
+        target_shape=(batch, frames, seq_len, depth),
+        num_samples=100,
+        log=log,
+    )
+
+    class _Calibrator(CalibrationDataReader):
+        def __init__(self, input_name: str, inputs: list[np.ndarray]):
+            self.input_name = input_name
+            self.inputs = inputs
+            self._idx = 0
+
+        def get_next(self):
+            if self._idx >= len(self.inputs):
+                return None
+            item = {self.input_name: self.inputs[self._idx]}
+            self._idx += 1
+            return item
+
+    calibrator = _Calibrator(input_name, calibration_inputs)
+
+    quantized_path = output_dir / f"{model_name}_int8.onnx"
+
+    log.info("Running INT8 static quantization (this may take a while)...")
+    try:
+        quantize_static(
+            model_input=input_model_path,
+            model_output=str(quantized_path),
+            calibration_data_reader=calibrator,
+            quant_format=QuantFormat.QDQ,
+            activation_type=QuantType.QInt8,
+            weight_type=QuantType.QInt8,
+            extra_options={
+                "ActivationSymmetric": True,
+                "WeightSymmetric": True,
+            },
+        )
+    except Exception as e:
+        log.error(f"INT8 quantization failed: {e}")
+        if preprocessed_path and preprocessed_path.exists():
+            preprocessed_path.unlink()
+        sys.exit(1)
+
+    # Clean up preprocessed intermediate
+    if preprocessed_path and preprocessed_path.exists():
+        preprocessed_path.unlink()
+
+    log.info(
+        f"Saved INT8 ONNX model: {quantized_path} "
+        f"({quantized_path.stat().st_size / 1024 / 1024:.1f} MB)"
+    )
+
+
+def _build_calibration_inputs(
+    graph_dir: Path,
+    target_shape: tuple[int, int, int, int],
+    num_samples: int,
+    log: logging.Logger,
+) -> list[np.ndarray]:
+    """Generate calibration inputs by running real DNA through the SavedModel.
+
+    Falls back to Gaussian noise if the real-data path fails.
+    """
+    from importlib.resources import files
+
+    batch, frames, seq_len, depth = target_shape
+    inputs: list[np.ndarray] = []
+
+    # Try to use bundled test FASTA for realistic calibration data
+    test_fasta = files("jaeger.data") / "test" / "test_contigs.fasta"
+    if not test_fasta.exists():
+        log.warning(
+            "No bundled test FASTA found; falling back to synthetic one-hot calibration data. "
+            "INT8 accuracy may be degraded."
+        )
+        return _synthetic_one_hot_samples(target_shape, num_samples)
+
+    try:
+        log.info(f"Building calibration dataset from {test_fasta}")
+
+        # Load model metadata needed for preprocessing
+        from jaeger.preprocess.fasta import fragment_generator
+        from jaeger.preprocess.latest.convert import process_string_inference
+        from jaeger.nnlib.inference import InferModel
+
+        # Use InferModel only for its metadata-loading helper; avoid creating
+        # a full session since we only need the string_processor_config.
+        _tmp_info = {"graph": graph_dir, "classes": None, "project": None}
+        _tmp_infer = InferModel.__new__(InferModel)
+        _tmp_infer.class_map = {}
+        _tmp_infer.string_processor_config = _tmp_infer._load_string_processor_config(None)
+
+        # We need the project YAML to get the real config. Try to find it next
+        # to the SavedModel directory.
+        project_yaml = graph_dir.parent / f"{graph_dir.parent.name}_project.yaml"
+        if not project_yaml.exists():
+            candidates = list(graph_dir.parent.glob("*_project.yaml"))
+            if candidates:
+                project_yaml = candidates[0]
+        if project_yaml.exists():
+            import yaml
+
+            with project_yaml.open() as fh:
+                _tmp_infer.string_processor_config = yaml.safe_load(fh)
+
+        spc = _tmp_infer.string_processor_config
+
+        # Build a tf.data pipeline from the test FASTA
+        dataset = tf.data.Dataset.from_generator(
+            fragment_generator(
+                file_path=str(test_fasta),
+                no_progress=True,
+                fragsize=spc.get("fragsize", 200),
+                stride=spc.get("stride", spc.get("fragsize", 200) // 2),
+            ),
+            output_signature=tf.TensorSpec(shape=(), dtype=tf.string),
+        )
+
+        process_fn = process_string_inference(
+            codons=spc.get("codon"),
+            codon_num=spc.get("codon_id"),
+            codon_depth=spc.get("codon_depth", 1),
+            ngram_width=spc.get("ngram_width", 3),
+            seq_onehot=spc.get("seq_onehot"),
+            crop_size=spc.get("crop_size"),
+            input_type=spc.get("input_type", "translated"),
+            masking=spc.get("masking"),
+            mutate=spc.get("mutate"),
+            mutation_rate=spc.get("mutation_rate"),
+            shuffle=spc.get("shuffle"),
+        )
+
+        dataset = dataset.map(process_fn, num_parallel_calls=tf.data.AUTOTUNE)
+        dataset = dataset.batch(1).prefetch(tf.data.AUTOTUNE)
+
+        # Run the original SavedModel to get calibrated inputs
+        loaded = tf.saved_model.load(str(graph_dir))
+        infer = loaded.signatures["serving_default"]
+        input_type = spc.get("input_type", "translated")
+
+        for inputs_dict in dataset.take(num_samples):
+            x = inputs_dict.get(input_type)
+            if isinstance(x, tf.Tensor):
+                x = x.numpy()
+            # Pad or crop to target seq_len
+            if x.shape[2] < seq_len:
+                pad = seq_len - x.shape[2]
+                x = np.pad(x, ((0, 0), (0, 0), (0, pad), (0, 0)), mode="constant")
+            elif x.shape[2] > seq_len:
+                x = x[:, :, :seq_len, :]
+            # Ensure depth matches
+            if x.shape[3] != depth:
+                if x.shape[3] < depth:
+                    pad_d = depth - x.shape[3]
+                    x = np.pad(x, ((0, 0), (0, 0), (0, 0), (0, pad_d)), mode="constant")
+                else:
+                    x = x[:, :, :, :depth]
+            inputs.append(x.astype(np.float32))
+
+        if not inputs:
+            raise RuntimeError("No calibration inputs generated from FASTA")
+
+        log.info(f"Generated {len(inputs)} real calibration samples")
+        return inputs
+
+    except Exception as e:
+        log.warning(
+            f"Failed to build real calibration dataset ({e}); "
+            "falling back to synthetic one-hot data. INT8 accuracy may be degraded."
+        )
+        return _synthetic_one_hot_samples(target_shape, num_samples)
+
+
+def _synthetic_one_hot_samples(
+    target_shape: tuple[int, int, int, int], num_samples: int
+) -> list[np.ndarray]:
+    """Generate random one-hot tensors matching codon-encoded DNA inputs.
+
+    Real Jaeger inputs are one-hot codon tensors (shape: B, 6, L, 64). Using
+    random one-hot samples for calibration is closer to the true distribution
+    than Gaussian noise and usually yields better INT8 accuracy.
+    """
+    batch, frames, seq_len, depth = target_shape
+    samples = []
+    for _ in range(num_samples):
+        indices = np.random.randint(0, depth, size=(batch, frames, seq_len))
+        one_hot = np.eye(depth)[indices].astype(np.float32)
+        samples.append(one_hot)
+    return samples
 
 
 def _convert_tensorrt(graph_dir: Path, output_dir: Path, model_name: str, log: logging.Logger):
@@ -285,13 +563,21 @@ def _convert_tensorrt(graph_dir: Path, output_dir: Path, model_name: str, log: l
     help="Conversion mode: xla (default), tflite, onnx, or tensorrt",
 )
 @click.option(
+    "--int8",
+    is_flag=True,
+    help=(
+        "Apply static INT8 quantization (ONNX mode only). "
+        "Produces a smaller model that can use TensorRT INT8 tensor cores."
+    ),
+)
+@click.option(
     "-v",
     "--verbose",
     count=True,
     help="Verbosity level",
     default=1,
 )
-def convert_graph_cmd(model: str, output: Path, mode: str, verbose: int):
+def convert_graph_cmd(model: str, output: Path, mode: str, int8: bool, verbose: int):
     """Convert a Jaeger SavedModel to an optimized inference graph.
 
     Supports four optimization backends:
@@ -310,7 +596,8 @@ def convert_graph_cmd(model: str, output: Path, mode: str, verbose: int):
     onnx:
         Converts to ONNX format for cross-platform deployment.
         Recommended for TensorRT acceleration with pip-installed TF.
-        Use with ONNX Runtime's TensorRT execution provider.
+        Use --int8 to additionally quantize to INT8 for smaller models
+        and INT8 tensor-core inference.
 
     \b
     tensorrt:
@@ -321,8 +608,9 @@ def convert_graph_cmd(model: str, output: Path, mode: str, verbose: int):
     Examples:
         jaeger utils convert-graph -m default -o ./optimized --mode xla
         jaeger utils convert-graph -m default -o ./optimized --mode onnx
+        jaeger utils convert-graph -m default -o ./optimized --mode onnx --int8
     """
-    convert_graph(model, output, mode, verbose)
+    convert_graph(model, output, mode, verbose, int8=int8)
 
 
 def _resolve_model(model_name: str) -> dict | None:

--- a/src/jaeger/commands/convert_graph.py
+++ b/src/jaeger/commands/convert_graph.py
@@ -1,0 +1,337 @@
+"""Graph conversion utilities for Jaeger.
+
+Supports optimizing SavedModel graphs for inference via:
+- XLA (JIT compilation)
+- TensorFlow Lite (mobile/edge deployment)
+- ONNX (cross-platform deployment with TensorRT/CUDA support)
+- TensorRT (NVIDIA GPU acceleration — requires TF built with TensorRT support)
+
+Usage:
+    jaeger utils convert-graph -m default -o ./optimized --mode xla
+    jaeger utils convert-graph -m default -o ./optimized --mode tflite
+    jaeger utils convert-graph -m default -o ./optimized --mode onnx
+    jaeger utils convert-graph -m default -o ./optimized --mode tensorrt
+"""
+
+from __future__ import annotations
+
+import logging
+import shutil
+import sys
+from pathlib import Path
+
+import click
+import numpy as np
+import tensorflow as tf
+import yaml
+from tensorflow.python.framework.convert_to_constants import convert_variables_to_constants_v2
+
+from jaeger.utils.misc import AvailableModels
+
+logger = logging.getLogger("Jaeger")
+
+
+def convert_graph(model: str, output: Path, mode: str, verbose: int):
+    """Core graph conversion logic (non-CLI)."""
+    log = logging.getLogger("Jaeger")
+    log.info(f"Converting model '{model}' with mode '{mode}'")
+
+    # Resolve model path
+    model_info = _resolve_model(model)
+    if model_info is None:
+        log.error(f"Model '{model}' not found")
+        sys.exit(1)
+
+    graph_dir = Path(model_info["graph"])
+    output = Path(output)
+    output.mkdir(parents=True, exist_ok=True)
+
+    # Create output subdirectory
+    converted_dir = output / f"{model}_{mode}"
+    if converted_dir.exists():
+        shutil.rmtree(converted_dir)
+    converted_dir.mkdir(parents=True)
+
+    # Copy metadata files
+    for key in ("classes", "project", "weights"):
+        if key in model_info and model_info[key]:
+            src = Path(model_info[key])
+            dst = converted_dir / src.name
+            shutil.copy2(src, dst)
+            log.info(f"Copied {key}: {src.name}")
+
+    if mode == "xla":
+        _convert_xla(graph_dir, converted_dir, model, log)
+    elif mode == "tflite":
+        _convert_tflite(graph_dir, converted_dir, model, log)
+    elif mode == "onnx":
+        _convert_onnx(graph_dir, converted_dir, model, log)
+    elif mode == "tensorrt":
+        _convert_tensorrt(graph_dir, converted_dir, model, log)
+    else:
+        log.error(f"Unknown conversion mode: {mode}")
+        sys.exit(1)
+
+    # Save conversion info
+    info = {
+        "original_graph": str(graph_dir),
+        "conversion_mode": mode,
+        "output_dir": str(converted_dir),
+    }
+    info_path = converted_dir / "conversion_info.yaml"
+    info_path.write_text(yaml.safe_dump(info))
+
+    log.info(f"Conversion complete. Output: {converted_dir}")
+
+
+def _convert_xla(graph_dir: Path, output_dir: Path, model_name: str, log: logging.Logger):
+    """Convert SavedModel to XLA-optimized SavedModel.
+
+    XLA (Accelerated Linear Algebra) uses JIT compilation to fuse operations
+    and optimize memory access patterns. This can provide 2-3x speedup on GPU
+    for compute-bound models after initial compilation overhead.
+    """
+    log.info("Loading SavedModel for XLA optimization...")
+    loaded = tf.saved_model.load(str(graph_dir))
+    infer = loaded.signatures["serving_default"]
+
+    log.info("Wrapping with XLA JIT compilation...")
+
+    # Create an XLA-optimized signature
+    @tf.function(jit_compile=True)
+    def xla_serving(inputs):
+        return infer(inputs=inputs)
+
+    # Trace with a representative input to build the graph
+    log.info("Tracing XLA graph (this may take a while)...")
+    rep_input = tf.constant(np.random.randn(1, 6, 500, 64).astype(np.float32))
+    _ = xla_serving(rep_input)
+
+    # Save as a new SavedModel
+    log.info(f"Saving XLA-optimized model to {output_dir}...")
+
+    class XLAModel(tf.Module):
+        def __init__(self, serving_fn):
+            super().__init__()
+            self.serving_fn = serving_fn
+
+        @tf.function(
+            input_signature=[
+                tf.TensorSpec(shape=(None, 6, None, 64), dtype=tf.float32, name="inputs")
+            ]
+        )
+        def serving_default(self, inputs):
+            return self.serving_fn(inputs)
+
+    xla_module = XLAModel(xla_serving)
+    tf.saved_model.save(xla_module, str(output_dir))
+    log.info("XLA model saved")
+
+
+def _convert_tflite(graph_dir: Path, output_dir: Path, model_name: str, log: logging.Logger):
+    """Convert SavedModel to TFLite (same as quantize but without quantization)."""
+    log.info("Loading SavedModel for TFLite conversion...")
+    loaded = tf.saved_model.load(str(graph_dir))
+    infer = loaded.signatures["serving_default"]
+
+    log.info("Converting to frozen graph...")
+    frozen_func = convert_variables_to_constants_v2(infer)
+
+    log.info("Converting to TFLite...")
+    converter = tf.lite.TFLiteConverter.from_concrete_functions([frozen_func])
+    converter.optimizations = [tf.lite.Optimize.DEFAULT]
+
+    tflite_model = converter.convert()
+
+    tflite_path = output_dir / f"{model_name}.tflite"
+    tflite_path.write_bytes(tflite_model)
+    log.info(f"Saved TFLite model: {tflite_path} ({len(tflite_model) / 1024:.1f} KB)")
+
+
+def _convert_onnx(graph_dir: Path, output_dir: Path, model_name: str, log: logging.Logger):
+    """Convert SavedModel to ONNX format.
+
+    ONNX models can be run with ONNX Runtime, which supports multiple
+    execution providers (TensorRT, CUDA, CPU) without requiring
+    TensorFlow to be built with those backends.
+
+    This is the recommended approach for TensorRT acceleration when
+    using pip-installed TensorFlow.
+    """
+    try:
+        import tf2onnx
+    except ImportError:
+        log.error(
+            "tf2onnx is not installed. Install it with:\n"
+            "  pip install tf2onnx onnxruntime-gpu"
+        )
+        sys.exit(1)
+
+    log.info("Converting SavedModel to ONNX...")
+
+    onnx_path = output_dir / f"{model_name}.onnx"
+
+    # Use tf2onnx to convert
+    import subprocess
+    cmd = [
+        sys.executable, "-m", "tf2onnx.convert",
+        "--saved-model", str(graph_dir),
+        "--output", str(onnx_path),
+        "--opset", "13",
+        "--signature", "serving_default",
+        "--tag", "serve",
+    ]
+
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        log.error(f"ONNX conversion failed:\n{result.stderr}")
+        sys.exit(1)
+
+    log.info(f"Saved ONNX model: {onnx_path} ({onnx_path.stat().st_size / 1024 / 1024:.1f} MB)")
+
+    # Verify the model
+    try:
+        import onnx
+        onnx_model = onnx.load(str(onnx_path))
+        onnx.checker.check_model(onnx_model)
+        log.info("ONNX model validation passed")
+    except Exception as e:
+        log.warning(f"ONNX validation warning: {e}")
+
+
+def _convert_tensorrt(graph_dir: Path, output_dir: Path, model_name: str, log: logging.Logger):
+    """Convert SavedModel to TensorRT-optimized SavedModel.
+
+    Requires TensorFlow built with TensorRT support. Most pip-installed
+    TensorFlow packages do NOT include TensorRT. Use NVIDIA's NGC containers
+    or build from source with --config=cuda and TensorRT headers.
+
+    Alternative: Use --mode onnx to create an ONNX model, then run with
+    ONNX Runtime's TensorRT execution provider.
+
+    When available, TensorRT can provide 2-5x speedup on NVIDIA GPUs by:
+    - Fusing layers (conv+bias+relu)
+    - Selecting optimal CUDA kernels
+    - Using FP16/INT8 tensor cores
+    """
+    try:
+        from tensorflow.python.compiler.tensorrt import trt_convert as trt
+    except ImportError:
+        log.error(
+            "TensorRT is not available. TensorFlow must be built with TensorRT support.\n"
+            "Options:\n"
+            "  1. Use NVIDIA NGC Docker container: nvcr.io/nvidia/tensorflow:xx.xx-tf2-py3\n"
+            "  2. Install tensorflow[and-cuda] with TensorRT headers present\n"
+            "  3. Build TensorFlow from source with --config=cuda and TensorRT\n"
+            "  4. Use --mode onnx instead, then run with ONNX Runtime + TensorRT"
+        )
+        sys.exit(1)
+
+    # Verify TRT is actually usable
+    try:
+        trt._check_trt_version_compatibility()
+    except RuntimeError as e:
+        log.error(f"TensorRT compatibility check failed: {e}")
+        sys.exit(1)
+
+    log.info("Loading SavedModel for TensorRT optimization...")
+
+    # Convert with TensorRT
+    params = trt.TrtConversionParams(
+        precision_mode=trt.TrtPrecisionMode.FP32,
+        max_workspace_size_bytes=8000000000,  # 8GB
+    )
+
+    converter = trt.TrtGraphConverterV2(
+        input_saved_model_dir=str(graph_dir),
+        conversion_params=params,
+    )
+
+    log.info("Converting to TensorRT graph...")
+    converter.convert()
+
+    log.info("Building TensorRT engines (this may take several minutes)...")
+
+    def input_fn():
+        for _ in range(10):
+            yield [np.random.randn(1, 6, 500, 64).astype(np.float32)]
+
+    converter.build(input_fn=input_fn)
+
+    log.info(f"Saving TensorRT-optimized model to {output_dir}...")
+    converter.save(str(output_dir))
+    log.info("TensorRT model saved")
+
+
+@click.command()
+@click.option(
+    "-m",
+    "--model",
+    type=str,
+    required=True,
+    help="Model name to convert (e.g., jaeger_57341_1.5M_fragment)",
+)
+@click.option(
+    "-o",
+    "--output",
+    type=click.Path(path_type=Path),
+    required=True,
+    help="Output directory for the converted model",
+)
+@click.option(
+    "--mode",
+    type=click.Choice(["xla", "tflite", "onnx", "tensorrt"]),
+    default="xla",
+    help="Conversion mode: xla (default), tflite, onnx, or tensorrt",
+)
+@click.option(
+    "-v",
+    "--verbose",
+    count=True,
+    help="Verbosity level",
+    default=1,
+)
+def convert_graph_cmd(model: str, output: Path, mode: str, verbose: int):
+    """Convert a Jaeger SavedModel to an optimized inference graph.
+
+    Supports four optimization backends:
+
+    \b
+    xla (default):
+        JIT-compiles the graph for GPU. Provides 2-3x speedup after
+        initial compilation. Best for large datasets with repeated shapes.
+
+    \b
+    tflite:
+        Converts to TensorFlow Lite for mobile/edge deployment.
+        Produces a smaller model (~3.5x size reduction).
+
+    \b
+    onnx:
+        Converts to ONNX format for cross-platform deployment.
+        Recommended for TensorRT acceleration with pip-installed TF.
+        Use with ONNX Runtime's TensorRT execution provider.
+
+    \b
+    tensorrt:
+        NVIDIA TensorRT optimization for maximum GPU performance.
+        Requires TensorFlow built with TensorRT support (not available
+        in standard pip packages). Use NVIDIA NGC containers.
+
+    Examples:
+        jaeger utils convert-graph -m default -o ./optimized --mode xla
+        jaeger utils convert-graph -m default -o ./optimized --mode onnx
+    """
+    convert_graph(model, output, mode, verbose)
+
+
+def _resolve_model(model_name: str) -> dict | None:
+    """Resolve model name to path dict."""
+    from importlib.resources import files
+
+    from jaeger.utils.misc import json_to_dict
+
+    CONFIG_PATH = files("jaeger.data") / "config.json"
+    model_paths = json_to_dict(CONFIG_PATH).get("model_paths", [])
+    models = AvailableModels(path=model_paths)
+    return models.info.get(model_name)

--- a/src/jaeger/commands/predict.py
+++ b/src/jaeger/commands/predict.py
@@ -182,6 +182,8 @@ def run_core(**kwargs):
 
     # Use quantized TFLite model if requested
     quantized_mode = kwargs.get("quantized")
+    use_xla = kwargs.get("xla", False)
+    
     if quantized_mode:
         # Look for quantized model in the same directory as the original model
         graph_dir = Path(model_info["graph"])
@@ -200,7 +202,9 @@ def run_core(**kwargs):
         model_info_tflite["tflite"] = tflite_path
         model = TFLiteInferModel(model_info_tflite)
     else:
-        model = InferModel(model_info)
+        if use_xla:
+            logger.info("Using XLA-compiled inference (first batch may be slow due to compilation)")
+        model = InferModel(model_info, use_xla=use_xla)
     
     string_processor_config = model.string_processor_config
     input_dataset = tf.data.Dataset.from_generator(

--- a/src/jaeger/commands/predict.py
+++ b/src/jaeger/commands/predict.py
@@ -11,7 +11,7 @@ from importlib.metadata import version
 from pathlib import Path
 import tensorflow as tf
 
-from jaeger.nnlib.inference import InferModel
+from jaeger.nnlib.inference import InferModel, TFLiteInferModel
 from jaeger.preprocess.fasta import fragment_generator
 from jaeger.utils.gpu import get_device_name
 from jaeger.utils.termini import scan_for_terminal_repeats
@@ -168,7 +168,28 @@ def run_core(**kwargs):
         fsize=kwargs.get("fsize"),
     )
 
-    model = InferModel(model_info)
+    # Use quantized TFLite model if requested
+    quantized_mode = kwargs.get("quantized")
+    if quantized_mode:
+        # Look for quantized model in the same directory as the original model
+        graph_dir = Path(model_info["graph"])
+        quantized_dir = graph_dir.parent / f"{model_name}_{quantized_mode}"
+        tflite_path = quantized_dir / f"{model_name}_{quantized_mode}.tflite"
+        
+        if not tflite_path.exists():
+            logger.error(
+                f"Quantized model not found at {tflite_path}. "
+                f"Run 'jaeger utils quantize -m {model_name} -o {graph_dir.parent} --mode {quantized_mode}' first."
+            )
+            sys.exit(1)
+        
+        logger.info(f"Using quantized model: {tflite_path}")
+        model_info_tflite = model_info.copy()
+        model_info_tflite["tflite"] = tflite_path
+        model = TFLiteInferModel(model_info_tflite)
+    else:
+        model = InferModel(model_info)
+    
     string_processor_config = model.string_processor_config
     input_dataset = tf.data.Dataset.from_generator(
         fragment_generator(

--- a/src/jaeger/commands/predict.py
+++ b/src/jaeger/commands/predict.py
@@ -184,6 +184,7 @@ def run_core(**kwargs):
     quantized_mode = kwargs.get("quantized")
     use_xla = kwargs.get("xla", False)
     use_onnx = kwargs.get("onnx", False)
+    use_onnx_int8 = kwargs.get("int8", False)
     
     if quantized_mode:
         # Look for quantized model in the same directory as the original model
@@ -203,21 +204,34 @@ def run_core(**kwargs):
         model_info_tflite["tflite"] = tflite_path
         model = TFLiteInferModel(model_info_tflite)
     elif use_onnx:
-        # Look for ONNX model
+        # Look for ONNX model (FP32 or INT8)
         graph_dir = Path(model_info["graph"])
-        onnx_dir = graph_dir.parent / f"{model_name}_onnx"
-        onnx_path = onnx_dir / f"{model_name}.onnx"
+        if use_onnx_int8:
+            onnx_dir = graph_dir.parent / f"{model_name}_onnx_int8"
+            onnx_path = onnx_dir / f"{model_name}_int8.onnx"
+            if not onnx_path.exists():
+                logger.error(
+                    f"INT8 ONNX model not found at {onnx_path}. "
+                    f"Run 'jaeger utils convert-graph -m {model_name} -o {graph_dir.parent} --mode onnx --int8' first."
+                )
+                sys.exit(1)
+            logger.info(f"Using INT8 ONNX model: {onnx_path}")
+        else:
+            onnx_dir = graph_dir.parent / f"{model_name}_onnx"
+            onnx_path = onnx_dir / f"{model_name}.onnx"
+            
+            if not onnx_path.exists():
+                logger.error(
+                    f"ONNX model not found at {onnx_path}. "
+                    f"Run 'jaeger utils convert-graph -m {model_name} -o {graph_dir.parent} --mode onnx' first."
+                )
+                sys.exit(1)
+            
+            logger.info(f"Using ONNX model: {onnx_path}")
         
-        if not onnx_path.exists():
-            logger.error(
-                f"ONNX model not found at {onnx_path}. "
-                f"Run 'jaeger utils convert-graph -m {model_name} -o {graph_dir.parent} --mode onnx' first."
-            )
-            sys.exit(1)
-        
-        logger.info(f"Using ONNX model: {onnx_path}")
         model_info_onnx = model_info.copy()
         model_info_onnx["onnx"] = onnx_path
+
         model = ONNXEngine(model_info_onnx)
     else:
         if use_xla:

--- a/src/jaeger/commands/predict.py
+++ b/src/jaeger/commands/predict.py
@@ -97,6 +97,18 @@ def run_core(**kwargs):
     elif gpus:
         mode = "GPU"
         tf.config.set_visible_devices([gpus[kwargs.get("physicalid")]], "GPU")
+
+        # Set mixed precision policy if requested
+        precision = kwargs.get("precision", "fp32")
+        if precision == "fp16":
+            tf.keras.mixed_precision.set_global_policy("mixed_float16")
+            logger.info("GPU precision: mixed_float16 (FP16 compute, FP32 variables)")
+        elif precision == "bf16":
+            tf.keras.mixed_precision.set_global_policy("mixed_bfloat16")
+            logger.info("GPU precision: mixed_bfloat16 (BF16 compute, FP32 variables)")
+        else:
+            logger.info("GPU precision: float32 (FP32)")
+
         try:
             tf.config.set_logical_device_configuration(
                 gpus[kwargs.get("physicalid")],

--- a/src/jaeger/commands/predict.py
+++ b/src/jaeger/commands/predict.py
@@ -315,6 +315,7 @@ def run_core(**kwargs):
             from jaeger.postprocess.prophages import (
                 logits_to_df_v2,
                 plot_scores,
+                plot_scores_linear,
                 prophage_report,
                 segment,
             )
@@ -342,20 +343,41 @@ def run_core(**kwargs):
                         sensitivity=kwargs.get("sensitivity"),
                         identifier="phage",
                     )
-                    plot_scores(
-                        logits_df,
-                        config={
-                            "all_labels": {
-                                i: c
-                                for i, c in enumerate(model.class_map.get("class", []))
-                            }
-                        },
-                        model=model_name,
-                        fsize=kwargs.get("fsize"),
-                        infile_base=file_base,
-                        outdir=plots_dir,
-                        phage_cordinates=phage_cord,
-                    )
+                    plot_type = kwargs.get("plot_type", "circular")
+                    if plot_type in ("circular", "both"):
+                        plot_scores(
+                            logits_df,
+                            config={
+                                "all_labels": {
+                                    i: c
+                                    for i, c in enumerate(
+                                        model.class_map.get("class", [])
+                                    )
+                                }
+                            },
+                            model=model_name,
+                            fsize=kwargs.get("fsize"),
+                            infile_base=file_base,
+                            outdir=plots_dir,
+                            phage_cordinates=phage_cord,
+                        )
+                    if plot_type in ("linear", "both"):
+                        plot_scores_linear(
+                            logits_df,
+                            config={
+                                "all_labels": {
+                                    i: c
+                                    for i, c in enumerate(
+                                        model.class_map.get("class", [])
+                                    )
+                                }
+                            },
+                            model=model_name,
+                            fsize=kwargs.get("fsize"),
+                            infile_base=file_base,
+                            outdir=plots_dir,
+                            phage_cordinates=phage_cord,
+                        )
                     prophage_report(
                         fsize=kwargs.get("fsize"),
                         filehandle=str(input_file_path),

--- a/src/jaeger/commands/predict.py
+++ b/src/jaeger/commands/predict.py
@@ -185,20 +185,20 @@ def run_core(**kwargs):
     use_xla = kwargs.get("xla", False)
     use_onnx = kwargs.get("onnx", False)
     use_onnx_int8 = kwargs.get("int8", False)
-    
+
     if quantized_mode:
         # Look for quantized model in the same directory as the original model
         graph_dir = Path(model_info["graph"])
         quantized_dir = graph_dir.parent / f"{model_name}_{quantized_mode}"
         tflite_path = quantized_dir / f"{model_name}_{quantized_mode}.tflite"
-        
+
         if not tflite_path.exists():
             logger.error(
                 f"Quantized model not found at {tflite_path}. "
                 f"Run 'jaeger utils quantize -m {model_name} -o {graph_dir.parent} --mode {quantized_mode}' first."
             )
             sys.exit(1)
-        
+
         logger.info(f"Using quantized model: {tflite_path}")
         model_info_tflite = model_info.copy()
         model_info_tflite["tflite"] = tflite_path
@@ -219,25 +219,27 @@ def run_core(**kwargs):
         else:
             onnx_dir = graph_dir.parent / f"{model_name}_onnx"
             onnx_path = onnx_dir / f"{model_name}.onnx"
-            
+
             if not onnx_path.exists():
                 logger.error(
                     f"ONNX model not found at {onnx_path}. "
                     f"Run 'jaeger utils convert-graph -m {model_name} -o {graph_dir.parent} --mode onnx' first."
                 )
                 sys.exit(1)
-            
+
             logger.info(f"Using ONNX model: {onnx_path}")
-        
+
         model_info_onnx = model_info.copy()
         model_info_onnx["onnx"] = onnx_path
 
         model = ONNXEngine(model_info_onnx)
     else:
         if use_xla:
-            logger.info("Using XLA-compiled inference (first batch may be slow due to compilation)")
+            logger.info(
+                "Using XLA-compiled inference (first batch may be slow due to compilation)"
+            )
         model = InferModel(model_info, use_xla=use_xla)
-    
+
     string_processor_config = model.string_processor_config
     input_dataset = tf.data.Dataset.from_generator(
         fragment_generator(

--- a/src/jaeger/commands/predict.py
+++ b/src/jaeger/commands/predict.py
@@ -293,7 +293,7 @@ def run_core(**kwargs):
 
         if kwargs.get("getalllabels"):
             pass
-        data, _ = pred_to_dict(
+        data, data_full = pred_to_dict(
             y_pred,
             class_map=model.class_map,
             fsize=kwargs.get("fsize"),
@@ -309,6 +309,94 @@ def run_core(**kwargs):
         )
 
         logger.info(f"processed {num_written}/{num} sequences")
+
+        # --- Prophage extraction ---
+        if kwargs.get("prophage"):
+            from jaeger.postprocess.prophages import (
+                logits_to_df_v2,
+                plot_scores,
+                prophage_report,
+                segment,
+            )
+
+            try:
+                if logits_df := logits_to_df_v2(
+                    class_map=model.class_map,
+                    cmdline_kwargs=kwargs,
+                    headers=data_full["headers"],
+                    predictions=data_full["predictions"],
+                    lengths=data_full["lengths"],
+                    gc_skews=data_full["gc_skews"],
+                    gcs=data_full["gcs"],
+                ):
+                    logger.info("identifying prophages")
+                    pro_dir = OUTPUT_DIR / f"{file_base}_prophages"
+                    plots_dir = pro_dir / "plots"
+                    for d in [pro_dir, plots_dir]:
+                        d.mkdir(parents=True, exist_ok=True)
+
+                    phage_cord = segment(
+                        logits_df,
+                        outdir=plots_dir,
+                        cutoff_length=kwargs.get("lc"),
+                        sensitivity=kwargs.get("sensitivity"),
+                        identifier="phage",
+                    )
+                    plot_scores(
+                        logits_df,
+                        config={
+                            "all_labels": {
+                                i: c
+                                for i, c in enumerate(model.class_map.get("class", []))
+                            }
+                        },
+                        model=model_name,
+                        fsize=kwargs.get("fsize"),
+                        infile_base=file_base,
+                        outdir=plots_dir,
+                        phage_cordinates=phage_cord,
+                    )
+                    prophage_report(
+                        fsize=kwargs.get("fsize"),
+                        filehandle=str(input_file_path),
+                        prophage_cordinates=phage_cord,
+                        outdir=pro_dir,
+                    )
+                else:
+                    logger.info("no prophage regions found")
+            except Exception as e:
+                logger.error(
+                    f"an error {e} occurred during the prophage prediction step"
+                )
+                logger.debug(traceback.format_exc())
+
+        # --- Write phage sequences to FASTA ---
+        if kwargs.get("getsequences"):
+            from jaeger.postprocess.collect import write_fasta_from_results
+
+            output_fasta_file = f"{file_base}_phages_jaeger.fasta"
+            output_fasta_file_path = OUTPUT_DIR / output_fasta_file
+            write_fasta_from_results(
+                input_fasta=input_file_path,
+                output_tsv=output_phage_table_path,
+                output_fasta=output_fasta_file_path,
+            )
+            logger.info(f"{output_fasta_file} created")
+
+        # --- Write window-wise logits ---
+        if kwargs.get("getalllogits"):
+            import numpy as np
+
+            output_logits = f"{file_base}_jaeger.npy"
+            output_logits_path = OUTPUT_DIR / output_logits
+            logger.info(f"writing window-wise scores to {output_logits}")
+            np.save(
+                output_logits_path,
+                dict(zip(data_full["headers"], data_full["predictions"])),
+                allow_pickle=True,
+            )
+            logger.info(f"{output_logits} created")
+
         logger.info(f"CPU time(s) : {current_process.cpu_times().user:.2f}")
         logger.info(f"wall time(s) : {time.time() - current_process.create_time():.2f}")
         logger.info(

--- a/src/jaeger/commands/predict.py
+++ b/src/jaeger/commands/predict.py
@@ -11,7 +11,7 @@ from importlib.metadata import version
 from pathlib import Path
 import tensorflow as tf
 
-from jaeger.nnlib.inference import InferModel, TFLiteInferModel
+from jaeger.nnlib.inference import InferModel, TFLiteInferModel, ONNXEngine
 from jaeger.preprocess.fasta import fragment_generator
 from jaeger.utils.gpu import get_device_name
 from jaeger.utils.termini import scan_for_terminal_repeats
@@ -180,9 +180,10 @@ def run_core(**kwargs):
         fsize=kwargs.get("fsize"),
     )
 
-    # Use quantized TFLite model if requested
+    # Select inference engine based on options
     quantized_mode = kwargs.get("quantized")
     use_xla = kwargs.get("xla", False)
+    use_onnx = kwargs.get("onnx", False)
     
     if quantized_mode:
         # Look for quantized model in the same directory as the original model
@@ -201,6 +202,23 @@ def run_core(**kwargs):
         model_info_tflite = model_info.copy()
         model_info_tflite["tflite"] = tflite_path
         model = TFLiteInferModel(model_info_tflite)
+    elif use_onnx:
+        # Look for ONNX model
+        graph_dir = Path(model_info["graph"])
+        onnx_dir = graph_dir.parent / f"{model_name}_onnx"
+        onnx_path = onnx_dir / f"{model_name}.onnx"
+        
+        if not onnx_path.exists():
+            logger.error(
+                f"ONNX model not found at {onnx_path}. "
+                f"Run 'jaeger utils convert-graph -m {model_name} -o {graph_dir.parent} --mode onnx' first."
+            )
+            sys.exit(1)
+        
+        logger.info(f"Using ONNX model: {onnx_path}")
+        model_info_onnx = model_info.copy()
+        model_info_onnx["onnx"] = onnx_path
+        model = ONNXEngine(model_info_onnx)
     else:
         if use_xla:
             logger.info("Using XLA-compiled inference (first batch may be slow due to compilation)")

--- a/src/jaeger/commands/predict_legacy.py
+++ b/src/jaeger/commands/predict_legacy.py
@@ -18,6 +18,7 @@ from jaeger.postprocess.collect import write_fasta_from_results
 from jaeger.postprocess.prophages import (
     logits_to_df,
     plot_scores,
+    plot_scores_linear,
     prophage_report,
     segment,
 )
@@ -292,15 +293,27 @@ def run_core(**kwargs):
                         sensitivity=kwargs.get("sensitivity"),
                         identifier="phage",
                     )
-                    plot_scores(
-                        logits_df,
-                        config=config,
-                        model=MODEL,
-                        fsize=kwargs.get("fsize"),
-                        infile_base=file_base,
-                        outdir=plots_dir,
-                        phage_cordinates=phage_cord,
-                    )
+                    plot_type = kwargs.get("plot_type", "circular")
+                    if plot_type in ("circular", "both"):
+                        plot_scores(
+                            logits_df,
+                            config=config,
+                            model=MODEL,
+                            fsize=kwargs.get("fsize"),
+                            infile_base=file_base,
+                            outdir=plots_dir,
+                            phage_cordinates=phage_cord,
+                        )
+                    if plot_type in ("linear", "both"):
+                        plot_scores_linear(
+                            logits_df,
+                            config=config,
+                            model=MODEL,
+                            fsize=kwargs.get("fsize"),
+                            infile_base=file_base,
+                            outdir=plots_dir,
+                            phage_cordinates=phage_cord,
+                        )
                     prophage_report(
                         fsize=kwargs.get("fsize"),
                         filehandle=str(input_file_path),

--- a/src/jaeger/commands/quantize.py
+++ b/src/jaeger/commands/quantize.py
@@ -26,7 +26,9 @@ import click
 import numpy as np
 import tensorflow as tf
 import yaml
-from tensorflow.python.framework.convert_to_constants import convert_variables_to_constants_v2
+from tensorflow.python.framework.convert_to_constants import (
+    convert_variables_to_constants_v2,
+)
 
 from jaeger.utils.misc import AvailableModels
 

--- a/src/jaeger/commands/quantize.py
+++ b/src/jaeger/commands/quantize.py
@@ -83,8 +83,11 @@ def quantize_model(model: str, output: Path, mode: str, verbose: int):
         converter.optimizations = [tf.lite.Optimize.DEFAULT]
         converter.representative_dataset = _make_rep_dataset()
         converter.target_spec.supported_ops = [tf.lite.OpsSet.TFLITE_BUILTINS_INT8]
-        converter.inference_input_type = tf.int8
-        converter.inference_output_type = tf.int8
+        # Keep input/output as FLOAT32 so the TFLite runtime handles
+        # quantization/dequantization automatically. This avoids needing
+        # to manually quantize inputs in the inference pipeline.
+        # converter.inference_input_type = tf.int8
+        # converter.inference_output_type = tf.int8
 
     try:
         tflite_model = converter.convert()

--- a/src/jaeger/commands/quantize.py
+++ b/src/jaeger/commands/quantize.py
@@ -1,0 +1,160 @@
+"""Model quantization utilities for Jaeger.
+
+Supports:
+- Dynamic range quantization (INT8 weights, FP32 activations)
+- Full integer quantization (INT8 weights and activations)
+- Float16 quantization (FP16 weights, FP32 activations)
+
+Note: Quantization is performed via TensorFlow Lite conversion.
+The quantized model is saved as a TFLite model alongside metadata.
+"""
+
+from __future__ import annotations
+
+import logging
+import shutil
+import sys
+from pathlib import Path
+
+import click
+import numpy as np
+import tensorflow as tf
+import yaml
+
+from jaeger.utils.misc import AvailableModels
+
+logger = logging.getLogger("Jaeger")
+
+
+def quantize_model(model: str, output: Path, mode: str, verbose: int):
+    """Core quantization logic (non-CLI)."""
+    from jaeger.utils.logging import get_logger
+
+    log = logging.getLogger("Jaeger")
+    log.info(f"Quantizing model '{model}' with mode '{mode}'")
+
+    # Resolve model path
+    model_info = _resolve_model(model)
+    if model_info is None:
+        log.error(f"Model '{model}' not found")
+        sys.exit(1)
+
+    graph_dir = Path(model_info["graph"])
+    output = Path(output)
+    output.mkdir(parents=True, exist_ok=True)
+
+    # Create output subdirectory
+    quantized_dir = output / f"{model}_{mode}"
+    if quantized_dir.exists():
+        shutil.rmtree(quantized_dir)
+    quantized_dir.mkdir(parents=True)
+
+    # Copy metadata files
+    for key in ("classes", "project", "weights"):
+        if key in model_info and model_info[key]:
+            src = Path(model_info[key])
+            dst = quantized_dir / src.name
+            shutil.copy2(src, dst)
+            log.info(f"Copied {key}: {src.name}")
+
+    # Perform quantization
+    log.info(f"Loading SavedModel from {graph_dir}")
+    converter = tf.lite.TFLiteConverter.from_saved_model(str(graph_dir))
+
+    if mode == "dynamic":
+        converter.optimizations = [tf.lite.Optimize.DEFAULT]
+    elif mode == "float16":
+        converter.optimizations = [tf.lite.Optimize.DEFAULT]
+        converter.target_spec.supported_types = [tf.float16]
+    elif mode == "full_int8":
+        converter.optimizations = [tf.lite.Optimize.DEFAULT]
+        converter.representative_dataset = _make_rep_dataset()
+        converter.target_spec.supported_ops = [tf.lite.OpsSet.TFLITE_BUILTINS_INT8]
+        converter.inference_input_type = tf.int8
+        converter.inference_output_type = tf.int8
+
+    # Disable resource variables (not supported by TFLite)
+    converter.experimental_enable_resource_variables = False
+
+    log.info("Converting model...")
+    try:
+        tflite_model = converter.convert()
+    except Exception as e:
+        log.error(f"Quantization failed: {e}")
+        sys.exit(1)
+
+    # Save TFLite model
+    tflite_path = quantized_dir / f"{model}_{mode}.tflite"
+    tflite_path.write_bytes(tflite_model)
+    log.info(
+        f"Saved quantized model: {tflite_path} ({len(tflite_model) / 1024:.1f} KB)"
+    )
+
+    # Save quantization info
+    info = {
+        "original_graph": str(graph_dir),
+        "quantization_mode": mode,
+        "tflite_model": str(tflite_path.name),
+        "model_format": "tflite",
+    }
+    info_path = quantized_dir / "quantization_info.yaml"
+    info_path.write_text(yaml.safe_dump(info))
+
+    log.info(f"Quantization complete. Output: {quantized_dir}")
+
+
+@click.command()
+@click.option(
+    "-m",
+    "--model",
+    type=str,
+    required=True,
+    help="Model name to quantize (e.g., jaeger_57341_1.5M_fragment)",
+)
+@click.option(
+    "-o",
+    "--output",
+    type=click.Path(path_type=Path),
+    required=True,
+    help="Output directory for the quantized model",
+)
+@click.option(
+    "--mode",
+    type=click.Choice(["dynamic", "float16", "full_int8"]),
+    default="dynamic",
+    help="Quantization mode",
+)
+@click.option(
+    "-v",
+    "--verbose",
+    count=True,
+    help="Verbosity level",
+    default=1,
+)
+def quantize(model: str, output: Path, mode: str, verbose: int):
+    """Quantize a Jaeger model for faster inference.
+
+    Examples:
+        jaeger utils quantize -m default -o ./quantized_models
+        jaeger utils quantize -m jaeger_57341_1.5M_fragment -o ./quantized --mode float16
+    """
+    quantize_model(model, output, mode, verbose)
+
+
+def _resolve_model(model_name: str) -> dict | None:
+    """Resolve model name to path dict."""
+    from importlib.resources import files; CONFIG_PATH = files("jaeger.data") / "config.json"; from jaeger.utils.misc import json_to_dict
+
+    model_paths = json_to_dict(CONFIG_PATH).get("model_paths", [])
+    models = AvailableModels(path=model_paths)
+    return models.info.get(model_name)
+
+
+def _make_rep_dataset():
+    """Create a representative dataset generator for INT8 quantization."""
+
+    def dataset_gen():
+        for _ in range(100):
+            yield [np.random.randn(1, 6, 100, 64).astype(np.float32)]
+
+    return dataset_gen

--- a/src/jaeger/commands/quantize.py
+++ b/src/jaeger/commands/quantize.py
@@ -80,6 +80,10 @@ def quantize_model(model: str, output: Path, mode: str, verbose: int):
         converter.optimizations = [tf.lite.Optimize.DEFAULT]
         converter.target_spec.supported_types = [tf.float16]
     elif mode == "full_int8":
+        log.warning(
+            "full_int8 mode is experimental and may reduce accuracy. "
+            "Use a representative dataset from your target domain for best results."
+        )
         converter.optimizations = [tf.lite.Optimize.DEFAULT]
         converter.representative_dataset = _make_rep_dataset()
         converter.target_spec.supported_ops = [tf.lite.OpsSet.TFLITE_BUILTINS_INT8]
@@ -138,7 +142,10 @@ def quantize_model(model: str, output: Path, mode: str, verbose: int):
     "--mode",
     type=click.Choice(["dynamic", "float16", "full_int8"]),
     default="dynamic",
-    help="Quantization mode",
+    help=(
+        "Quantization mode. dynamic (default) is recommended. "
+        "full_int8 is experimental and may reduce accuracy."
+    ),
 )
 @click.option(
     "-v",

--- a/src/jaeger/commands/quantize.py
+++ b/src/jaeger/commands/quantize.py
@@ -7,6 +7,12 @@ Supports:
 
 Note: Quantization is performed via TensorFlow Lite conversion.
 The quantized model is saved as a TFLite model alongside metadata.
+
+Important:
+    TFLite models produced by this tool are primarily intended for
+    edge/mobile deployment where model size matters. On desktop GPUs,
+    TFLite inference may not be faster than the original SavedModel
+    due to fallback TF ops and interpreter overhead.
 """
 
 from __future__ import annotations
@@ -20,6 +26,7 @@ import click
 import numpy as np
 import tensorflow as tf
 import yaml
+from tensorflow.python.framework.convert_to_constants import convert_variables_to_constants_v2
 
 from jaeger.utils.misc import AvailableModels
 
@@ -28,8 +35,6 @@ logger = logging.getLogger("Jaeger")
 
 def quantize_model(model: str, output: Path, mode: str, verbose: int):
     """Core quantization logic (non-CLI)."""
-    from jaeger.utils.logging import get_logger
-
     log = logging.getLogger("Jaeger")
     log.info(f"Quantizing model '{model}' with mode '{mode}'")
 
@@ -57,9 +62,17 @@ def quantize_model(model: str, output: Path, mode: str, verbose: int):
             shutil.copy2(src, dst)
             log.info(f"Copied {key}: {src.name}")
 
-    # Perform quantization
+    # Perform quantization via frozen graph -> TFLite
+    # Frozen graph eliminates resource variables that TFLite cannot handle.
     log.info(f"Loading SavedModel from {graph_dir}")
-    converter = tf.lite.TFLiteConverter.from_saved_model(str(graph_dir))
+    loaded = tf.saved_model.load(str(graph_dir))
+    infer = loaded.signatures["serving_default"]
+
+    log.info("Freezing graph (converting variables to constants)...")
+    frozen_func = convert_variables_to_constants_v2(infer)
+
+    log.info(f"Converting to TFLite (mode={mode})...")
+    converter = tf.lite.TFLiteConverter.from_concrete_functions([frozen_func])
 
     if mode == "dynamic":
         converter.optimizations = [tf.lite.Optimize.DEFAULT]
@@ -73,10 +86,6 @@ def quantize_model(model: str, output: Path, mode: str, verbose: int):
         converter.inference_input_type = tf.int8
         converter.inference_output_type = tf.int8
 
-    # Disable resource variables (not supported by TFLite)
-    converter.experimental_enable_resource_variables = False
-
-    log.info("Converting model...")
     try:
         tflite_model = converter.convert()
     except Exception as e:
@@ -96,6 +105,10 @@ def quantize_model(model: str, output: Path, mode: str, verbose: int):
         "quantization_mode": mode,
         "tflite_model": str(tflite_path.name),
         "model_format": "tflite",
+        "note": (
+            "TFLite model for edge deployment. "
+            "Resize interpreter input tensor at runtime for variable sequence lengths."
+        ),
     }
     info_path = quantized_dir / "quantization_info.yaml"
     info_path.write_text(yaml.safe_dump(info))
@@ -132,7 +145,12 @@ def quantize_model(model: str, output: Path, mode: str, verbose: int):
     default=1,
 )
 def quantize(model: str, output: Path, mode: str, verbose: int):
-    """Quantize a Jaeger model for faster inference.
+    """Quantize a Jaeger model for edge deployment.
+
+    Converts a SavedModel to a quantized TensorFlow Lite model. The primary
+    benefit is reduced model size (e.g., ~6 MB -> ~1.6 MB with dynamic
+    quantization). Note that TFLite inference speed depends heavily on the
+    target hardware and may not exceed the original SavedModel on desktop GPUs.
 
     Examples:
         jaeger utils quantize -m default -o ./quantized_models
@@ -143,8 +161,11 @@ def quantize(model: str, output: Path, mode: str, verbose: int):
 
 def _resolve_model(model_name: str) -> dict | None:
     """Resolve model name to path dict."""
-    from importlib.resources import files; CONFIG_PATH = files("jaeger.data") / "config.json"; from jaeger.utils.misc import json_to_dict
+    from importlib.resources import files
 
+    from jaeger.utils.misc import json_to_dict
+
+    CONFIG_PATH = files("jaeger.data") / "config.json"
     model_paths = json_to_dict(CONFIG_PATH).get("model_paths", [])
     models = AvailableModels(path=model_paths)
     return models.info.get(model_name)

--- a/src/jaeger/nnlib/inference.py
+++ b/src/jaeger/nnlib/inference.py
@@ -582,7 +582,12 @@ class ONNXEngine:
         jaeger utils convert-graph -m <model> -o <dir> --mode onnx
     """
 
-    def __init__(self, path_dict, providers: list[str] | None = None):
+    def __init__(
+        self,
+        path_dict,
+        providers: list[str] | None = None,
+        provider_options: list[dict] | None = None,
+    ):
         self.class_map = self._load_class_map(path_dict.get("classes"))
         self.string_processor_config = self._load_string_processor_config(
             path_dict.get("project", None)
@@ -610,24 +615,62 @@ class ONNXEngine:
                 "  pip install onnxruntime      # for CPU only"
             )
 
+        # Detect INT8 quantized models so we can avoid TensorRT, which has
+        # limited support for arbitrary quantized ONNX subgraphs.
+        is_int8 = self._is_int8_model(str(onnx_path))
+
         # Auto-select providers if not specified
         if providers is None:
             available = ort.get_available_providers()
-            # Prefer TensorRT > CUDA > CPU
-            preferred = [
-                "TensorrtExecutionProvider",
-                "CUDAExecutionProvider",
-                "CPUExecutionProvider",
-            ]
+            if is_int8:
+                # TensorRT's ONNX parser has strict requirements for quantized
+                # ops (symmetric quantization, no dynamic shapes, etc.). INT8
+                # ONNX models run reliably on the CUDA execution provider.
+                preferred = [
+                    "CUDAExecutionProvider",
+                    "CPUExecutionProvider",
+                ]
+            else:
+                # Prefer TensorRT > CUDA > CPU for FP32/FP16 models
+                preferred = [
+                    "TensorrtExecutionProvider",
+                    "CUDAExecutionProvider",
+                    "CPUExecutionProvider",
+                ]
             providers = [p for p in preferred if p in available]
             if not providers:
                 providers = ["CPUExecutionProvider"]
 
         self.providers = providers
-        self.session = ort.InferenceSession(str(onnx_path), providers=providers)
+        sess_options = ort.SessionOptions()
+        if provider_options is None:
+            provider_options = [{} for _ in providers]
+        self.session = ort.InferenceSession(
+            str(onnx_path),
+            sess_options=sess_options,
+            providers=providers,
+            provider_options=provider_options,
+        )
 
         self.input_name = self.session.get_inputs()[0].name
         self.output_names = [o.name for o in self.session.get_outputs()]
+
+    @staticmethod
+    def _is_int8_model(onnx_path: str) -> bool:
+        """Heuristic: check if ONNX model contains INT8 quantized tensors."""
+        try:
+            import onnx
+
+            model = onnx.load(onnx_path)
+            for init in model.graph.initializer:
+                if init.data_type == onnx.TensorProto.INT8:
+                    return True
+            for node in model.graph.node:
+                if node.op_type in ("QuantizeLinear", "DequantizeLinear"):
+                    return True
+            return False
+        except Exception:
+            return False
 
     @staticmethod
     def _preload_cuda_libs():

--- a/src/jaeger/nnlib/inference.py
+++ b/src/jaeger/nnlib/inference.py
@@ -20,7 +20,6 @@ from jaeger.preprocess.latest.maps import (
 from jaeger.nnlib.v2.layers import (
     GeLU,
     ReLU,
-    MaskedBatchNorm,
     MaskedConv1D,
     ResidualBlock,
 )
@@ -143,8 +142,6 @@ class DynamicInferenceModelBuilder:
     def _build_embedding(self, cfg: Dict[str, Any]):
         """Builds the embedding layer based on config."""
         input_shape = cfg.get("input_shape")
-        frames = cfg.get("frames", 6)
-        embedding_size = cfg.get("embedding_size", 128)
         seq_type = cfg.get("type", "translated")
 
         if seq_type == "translated":
@@ -206,9 +203,9 @@ class DynamicInferenceModelBuilder:
                     kernel_size=ksize,
                     dilation_rate=dilation,
                     strides=strides if j == 0 else 1,
-                    kernel_regularizer=self._regularizer.get(reg, tf.keras.regularizers.L2)(
-                        reg_w
-                    ),
+                    kernel_regularizer=self._regularizer.get(
+                        reg, tf.keras.regularizers.L2
+                    )(reg_w),
                     name=f"resblock_{i}_{j}",
                 )(x)
             if pooling == "max":
@@ -253,7 +250,9 @@ class DynamicInferenceModelBuilder:
             )(x)
             x = self.Activation(name=f"activation_dense_{i}")(x)
             if layer_cfg.get("dropout_rate", 0) > 0:
-                x = tf.keras.layers.Dropout(layer_cfg["dropout_rate"], name=f"dropout_{i}")(x)
+                x = tf.keras.layers.Dropout(
+                    layer_cfg["dropout_rate"], name=f"dropout_{i}"
+                )(x)
 
         # Output layer
         x = tf.keras.layers.Dense(
@@ -708,7 +707,10 @@ class ONNXEngine:
                 )
                 for candidate in candidates:
                     # Only load actual shared objects (not .a or .la)
-                    if not candidate.name.endswith(".so") and ".so." not in candidate.name:
+                    if (
+                        not candidate.name.endswith(".so")
+                        and ".so." not in candidate.name
+                    ):
                         continue
                     try:
                         ctypes.CDLL(str(candidate), mode=ctypes.RTLD_GLOBAL)

--- a/src/jaeger/nnlib/inference.py
+++ b/src/jaeger/nnlib/inference.py
@@ -278,22 +278,29 @@ class InferModel:
     (works with latest generation of models)
     """
 
-    def __init__(self, path_dict):
+    def __init__(self, path_dict, use_xla: bool = False):
         self.class_map = self._load_class_map(path_dict.get("classes"))
         self.loaded_model = tf.saved_model.load(path_dict.get("graph"))
         self.inference_fn = self.loaded_model.signatures["serving_default"]
         self.string_processor_config = self._load_string_processor_config(
             path_dict.get("project", None)
         )
+        self.use_xla = use_xla
+        self._predict_step = self._build_predict_step()
 
-    @tf.function(jit_compile=False)
-    def _predict_step(self, x):
-        # Unpack the data
-        # set model to inference mode
-        y_logits = self.inference_fn(
-            inputs=x.get(self.string_processor_config.get("input_type"))
-        )
-        return y_logits
+    def _build_predict_step(self):
+        """Build the prediction step function, optionally with XLA."""
+        inference_fn = self.inference_fn
+        input_type = self.string_processor_config.get("input_type")
+
+        def step(x):
+            y_logits = inference_fn(inputs=x.get(input_type))
+            return y_logits
+
+        if self.use_xla:
+            return tf.function(jit_compile=True)(step)
+        else:
+            return tf.function(jit_compile=False)(step)
 
     def predict(self, dataset, no_progress: bool = False) -> dict[str, np.ndarray]:
         """

--- a/src/jaeger/nnlib/inference.py
+++ b/src/jaeger/nnlib/inference.py
@@ -596,6 +596,11 @@ class ONNXEngine:
                 "Run 'jaeger utils convert-graph --mode onnx' first."
             )
 
+        # Preload pip-installed NVIDIA libraries so ONNX Runtime providers
+        # (CUDA, TensorRT) can find them without requiring LD_LIBRARY_PATH
+        # to be set externally.
+        self._preload_cuda_libs()
+
         try:
             import onnxruntime as ort
         except ImportError:
@@ -623,6 +628,72 @@ class ONNXEngine:
 
         self.input_name = self.session.get_inputs()[0].name
         self.output_names = [o.name for o in self.session.get_outputs()]
+
+    @staticmethod
+    def _preload_cuda_libs():
+        """Preload pip-installed NVIDIA shared libraries via ctypes.
+
+        ONNX Runtime's CUDA/TensorRT providers are compiled against specific
+        cuDNN/TensorRT SONAMEs. When these are installed as pip packages
+        (e.g., nvidia-cudnn-cu12, tensorrt), they live under site-packages
+        and are not on the system's LD_LIBRARY_PATH. Preloading with
+        RTLD_GLOBAL makes their symbols available to the provider libraries
+        when onnxruntime loads them.
+        """
+        import ctypes
+        import site
+
+        # Libraries that ONNX Runtime CUDA/TensorRT providers depend on.
+        # Preload the major SONAMEs; actual filenames may include version suffixes.
+        lib_patterns = [
+            ("nvidia/cudnn/lib", "libcudnn.so"),
+            ("tensorrt_libs", "libnvinfer.so"),
+            ("tensorrt_libs", "libnvonnxparser.so"),
+        ]
+
+        preloaded = []
+        for site_dir in site.getsitepackages():
+            for subdir, lib_name in lib_patterns:
+                lib_dir = Path(site_dir) / subdir
+                if not lib_dir.exists():
+                    continue
+                # Find the newest matching .so file
+                candidates = sorted(
+                    lib_dir.glob(f"{lib_name}*"),
+                    key=lambda p: p.stat().st_mtime,
+                    reverse=True,
+                )
+                for candidate in candidates:
+                    # Only load actual shared objects (not .a or .la)
+                    if not candidate.name.endswith(".so") and ".so." not in candidate.name:
+                        continue
+                    try:
+                        ctypes.CDLL(str(candidate), mode=ctypes.RTLD_GLOBAL)
+                        preloaded.append(candidate.name)
+                        break  # Only load one version per pattern
+                    except OSError:
+                        pass
+
+        # Also update LD_LIBRARY_PATH for any child processes
+        import os
+
+        nvidia_lib_dirs = []
+        for site_dir in site.getsitepackages():
+            nvidia_base = Path(site_dir) / "nvidia"
+            if nvidia_base.exists():
+                nvidia_lib_dirs.extend(
+                    sorted(str(d) for d in nvidia_base.rglob("lib") if d.is_dir())
+                )
+            trt_libs = Path(site_dir) / "tensorrt_libs"
+            if trt_libs.exists():
+                nvidia_lib_dirs.append(str(trt_libs))
+
+        if nvidia_lib_dirs:
+            current = os.environ.get("LD_LIBRARY_PATH", "")
+            current_parts = current.split(":") if current else []
+            new_parts = [p for p in nvidia_lib_dirs if p not in current_parts]
+            if new_parts:
+                os.environ["LD_LIBRARY_PATH"] = ":".join(new_parts + current_parts)
 
     def predict(self, dataset, no_progress: bool = False) -> dict[str, np.ndarray]:
         """

--- a/src/jaeger/nnlib/inference.py
+++ b/src/jaeger/nnlib/inference.py
@@ -566,3 +566,327 @@ class TFLiteInferModel:
             if _config["seq_onehot"] is False:
                 _config["codon_depth"] = 1
         return _config
+
+
+class ONNXEngine:
+    """
+    ONNX Runtime inference engine for Jaeger models.
+
+    Loads an ONNX model and runs inference via ONNX Runtime.
+    Supports multiple execution providers:
+    - TensorRT (fastest on NVIDIA GPUs)
+    - CUDA (NVIDIA GPU fallback)
+    - CPU (universal fallback)
+
+    The ONNX model should be created using:
+        jaeger utils convert-graph -m <model> -o <dir> --mode onnx
+    """
+
+    def __init__(self, path_dict, providers: list[str] | None = None):
+        self.class_map = self._load_class_map(path_dict.get("classes"))
+        self.string_processor_config = self._load_string_processor_config(
+            path_dict.get("project", None)
+        )
+
+        # Load ONNX model
+        onnx_path = path_dict.get("onnx")
+        if onnx_path is None or not Path(onnx_path).exists():
+            raise ValueError(
+                f"ONNX model not found at {onnx_path}. "
+                "Run 'jaeger utils convert-graph --mode onnx' first."
+            )
+
+        try:
+            import onnxruntime as ort
+        except ImportError:
+            raise ImportError(
+                "onnxruntime is not installed. Install it with:\n"
+                "  pip install onnxruntime-gpu  # for GPU\n"
+                "  pip install onnxruntime      # for CPU only"
+            )
+
+        # Auto-select providers if not specified
+        if providers is None:
+            available = ort.get_available_providers()
+            # Prefer TensorRT > CUDA > CPU
+            preferred = [
+                "TensorrtExecutionProvider",
+                "CUDAExecutionProvider",
+                "CPUExecutionProvider",
+            ]
+            providers = [p for p in preferred if p in available]
+            if not providers:
+                providers = ["CPUExecutionProvider"]
+
+        self.providers = providers
+        self.session = ort.InferenceSession(str(onnx_path), providers=providers)
+
+        self.input_name = self.session.get_inputs()[0].name
+        self.output_names = [o.name for o in self.session.get_outputs()]
+
+    def predict(self, dataset, no_progress: bool = False) -> dict[str, np.ndarray]:
+        """
+        dataset: yields tuples (inputs_dict, meta0, meta1, …)
+        Returns a dict of numpy arrays, each of shape (N, …)
+        """
+        acc: dict[str, list[np.ndarray]] = defaultdict(list)
+        input_name = self.input_name
+        output_names = self.output_names
+        session = self.session
+        input_type = self.string_processor_config.get("input_type", "translated")
+
+        for inputs, *meta in track(
+            dataset, description="[cyan]Crunching data…", disable=no_progress
+        ):
+            x = inputs.get(input_type)
+            if isinstance(x, tf.Tensor):
+                x = x.numpy()
+
+            # Run inference
+            outputs = session.run(output_names, {input_name: x})
+
+            # Map outputs (prediction, reliability)
+            acc["prediction"].append(outputs[0])
+            acc["reliability"].append(outputs[1])
+
+            # meta data
+            for idx, m in enumerate(meta):
+                if isinstance(m, tf.Tensor):
+                    m = m.numpy()
+                acc[f"meta_{idx}"].append(m)
+
+        # concatenate arrays; keep lists for non-array metadata
+        result: dict[str, np.ndarray] = {}
+        for k, arr_list in acc.items():
+            if k.startswith("meta_"):
+                try:
+                    result[k] = np.concatenate(arr_list, axis=0)
+                except ValueError:
+                    result[k] = arr_list
+            else:
+                result[k] = np.concatenate(arr_list, axis=0)
+        return result
+
+    def evaluate(self, dataset, no_progress: bool = False) -> dict[str, float]:
+        """Evaluate on a dataset."""
+        logits_acc: list[np.ndarray] = []
+        true_acc: list[np.ndarray] = []
+        input_name = self.input_name
+        session = self.session
+        input_type = self.string_processor_config.get("input_type", "translated")
+
+        for inputs, y_true in track(
+            dataset, description="[cyan]Evaluating…", disable=no_progress
+        ):
+            x = inputs.get(input_type)
+            if isinstance(x, tf.Tensor):
+                x = x.numpy()
+
+            outputs = session.run(None, {input_name: x})
+            logits = outputs[0]  # prediction is first output
+
+            logits_acc.append(logits)
+            true_acc.append(y_true.numpy() if isinstance(y_true, tf.Tensor) else y_true)
+
+        logits = np.concatenate(logits_acc, axis=0)
+        y_true = np.concatenate(true_acc, axis=0)
+
+        loss = tf.keras.losses.categorical_crossentropy(
+            y_true, logits, from_logits=True
+        )
+        loss = float(tf.reduce_mean(loss).numpy())
+
+        pred_labels = np.argmax(logits, axis=1)
+        true_labels = np.argmax(y_true, axis=1)
+        accuracy = float(np.mean(pred_labels == true_labels))
+
+        return {"loss": loss, "accuracy": accuracy}
+
+    def _load_class_map(self, path):
+        with open(path) as f:
+            _class_map = yaml.safe_load(f)["classes"]
+            return {
+                "num_classes": len(_class_map),
+                "class": [i["class"] for i in _class_map],
+                "index": [i["label"] for i in _class_map],
+            }
+
+    def _load_string_processor_config(self, path) -> Dict:
+        _map = {
+            "CODON": CODONS,
+            "CODON_ID": CODON_ID,
+            "AA_ID": AA_ID,
+            "MURPHY10_ID": MURPHY10_ID,
+            "PC5_ID": PC5_ID,
+            "DICODON": DICODONS,
+            "DICODON_ID": DICODON_ID,
+        }
+
+        if path is None:
+            return {"input_type": "translated"}
+
+        _config = yaml.safe_load(Path(path).read_text()) or {}
+        _model_cfg = _config.get("model")
+        _config = _model_cfg.get("embedding")
+        _config.update(_model_cfg.get("string_processor"))
+        _config["input_type"] = _config.get("type", "translated")
+
+        if _config["codon"] is not None and _config["codon_id"] is not None:
+            _config["codon"] = _map.get(_config.get("codon"))
+            _config["codon_id"] = _map.get(_config.get("codon_id"))
+            _config["codon_depth"] = max(_config.get("codon_id")) + 1
+            _config["vocab_size"] = len(_config.get("codon_id")) + 1
+            _config["ngram_width"] = int(math.log(len(_config["codon"]), 4))
+            input_shape = _model_cfg.get("embedding", {}).get("input_shape")
+            if _config.get("seq_onehot") is None and input_shape is not None:
+                _config["seq_onehot"] = (
+                    len(input_shape) == 3
+                    and input_shape[-1] is not None
+                    and input_shape[-1] > 1
+                )
+            _config["seq_onehot"] = _config.get("seq_onehot", False)
+            if _config["seq_onehot"] is False:
+                _config["codon_depth"] = 1
+        return _config
+
+
+class TensorRTEngine:
+    """
+    TensorRT inference engine for Jaeger models.
+
+    Loads a TensorRT-optimized SavedModel and runs inference.
+    Requires TensorFlow built with TensorRT support.
+
+    The TensorRT-optimized model should be created using:
+        jaeger utils convert-graph -m <model> -o <dir> --mode tensorrt
+    """
+
+    def __init__(self, path_dict):
+        self.class_map = self._load_class_map(path_dict.get("classes"))
+        self.string_processor_config = self._load_string_processor_config(
+            path_dict.get("project", None)
+        )
+
+        # Load TensorRT-optimized SavedModel
+        trt_dir = path_dict.get("trt_graph")
+        if trt_dir is None or not Path(trt_dir).exists():
+            raise ValueError(
+                f"TensorRT model not found at {trt_dir}. "
+                "Run 'jaeger utils convert-graph --mode tensorrt' first.\n"
+                "Note: TensorRT requires TensorFlow built with TensorRT support."
+            )
+
+        self.loaded_model = tf.saved_model.load(str(trt_dir))
+        self.inference_fn = self.loaded_model.signatures["serving_default"]
+
+        # Build predict step with XLA for additional optimization
+        input_type = self.string_processor_config.get("input_type")
+        inference_fn = self.inference_fn
+
+        @tf.function(jit_compile=True)
+        def _predict_step(x):
+            return inference_fn(inputs=x.get(input_type))
+
+        self._predict_step = _predict_step
+
+    def predict(self, dataset, no_progress: bool = False) -> dict[str, np.ndarray]:
+        """
+        dataset: yields tuples (inputs_dict, meta0, meta1, …)
+        Returns a dict of numpy arrays, each of shape (N, …)
+        """
+        acc: dict[str, list[np.ndarray]] = defaultdict(list)
+        inf_fn = self._predict_step
+
+        for inputs, *meta in track(
+            dataset, description="[cyan]Crunching data…", disable=no_progress
+        ):
+            logits = inf_fn(inputs)
+            for k, t in logits.items():
+                acc[k].append(t.numpy())
+            for idx, m in enumerate(meta):
+                acc[f"meta_{idx}"].append(m)
+
+        result: dict[str, np.ndarray] = {}
+        for k, arr_list in acc.items():
+            if k.startswith("meta_"):
+                try:
+                    result[k] = np.concatenate(arr_list, axis=0)
+                except ValueError:
+                    result[k] = arr_list
+            else:
+                result[k] = np.concatenate(arr_list, axis=0)
+        return result
+
+    def evaluate(self, dataset, no_progress: bool = False) -> dict[str, float]:
+        """Evaluate on a dataset."""
+        logits_acc: list[np.ndarray] = []
+        true_acc: list[np.ndarray] = []
+        inf_fn = self._predict_step
+
+        for inputs, y_true in track(
+            dataset, description="[cyan]Evaluating…", disable=no_progress
+        ):
+            logits = inf_fn(inputs)["prediction"]
+            logits_acc.append(logits.numpy())
+            true_acc.append(y_true.numpy())
+
+        logits = np.concatenate(logits_acc, axis=0)
+        y_true = np.concatenate(true_acc, axis=0)
+
+        loss = tf.keras.losses.categorical_crossentropy(
+            y_true, logits, from_logits=True
+        )
+        loss = float(tf.reduce_mean(loss).numpy())
+
+        pred_labels = np.argmax(logits, axis=1)
+        true_labels = np.argmax(y_true, axis=1)
+        accuracy = float(np.mean(pred_labels == true_labels))
+
+        return {"loss": loss, "accuracy": accuracy}
+
+    def _load_class_map(self, path):
+        with open(path) as f:
+            _class_map = yaml.safe_load(f)["classes"]
+            return {
+                "num_classes": len(_class_map),
+                "class": [i["class"] for i in _class_map],
+                "index": [i["label"] for i in _class_map],
+            }
+
+    def _load_string_processor_config(self, path) -> Dict:
+        _map = {
+            "CODON": CODONS,
+            "CODON_ID": CODON_ID,
+            "AA_ID": AA_ID,
+            "MURPHY10_ID": MURPHY10_ID,
+            "PC5_ID": PC5_ID,
+            "DICODON": DICODONS,
+            "DICODON_ID": DICODON_ID,
+        }
+
+        if path is None:
+            return {"input_type": "translated"}
+
+        _config = yaml.safe_load(Path(path).read_text()) or {}
+        _model_cfg = _config.get("model")
+        _config = _model_cfg.get("embedding")
+        _config.update(_model_cfg.get("string_processor"))
+        _config["input_type"] = _config.get("type", "translated")
+
+        if _config["codon"] is not None and _config["codon_id"] is not None:
+            _config["codon"] = _map.get(_config.get("codon"))
+            _config["codon_id"] = _map.get(_config.get("codon_id"))
+            _config["codon_depth"] = max(_config.get("codon_id")) + 1
+            _config["vocab_size"] = len(_config.get("codon_id")) + 1
+            _config["ngram_width"] = int(math.log(len(_config["codon"]), 4))
+            input_shape = _model_cfg.get("embedding", {}).get("input_shape")
+            if _config.get("seq_onehot") is None and input_shape is not None:
+                _config["seq_onehot"] = (
+                    len(input_shape) == 3
+                    and input_shape[-1] is not None
+                    and input_shape[-1] > 1
+                )
+            _config["seq_onehot"] = _config.get("seq_onehot", False)
+            if _config["seq_onehot"] is False:
+                _config["codon_depth"] = 1
+        return _config

--- a/src/jaeger/nnlib/inference.py
+++ b/src/jaeger/nnlib/inference.py
@@ -118,246 +118,157 @@ class DynamicInferenceModelBuilder:
 
         # === 2. REPRESENTATION LEARNER ===
         if "representation_learner" in self.model_cfg:
-            r, r_lbn = self._build_representation_learner(
-                x, self.model_cfg["representation_learner"]
+            x, r_lbn = self._build_representation_learner(
+                self.model_cfg["representation_learner"], x
             )
-            models["rep_model"] = tf.keras.Model(
-                inputs=self.inputs, outputs=[r, r_lbn], name="rep_model"
-            )
+        else:
+            raise ValueError("Missing 'representation_learner' section in config")
 
         # === 3. CLASSIFIER ===
         if "classifier" in self.model_cfg:
-            input_shape = (
-                self.model_cfg["representation_learner"].get("block_filters")[-1],
-            )
-            inputs = tf.keras.Input(shape=input_shape, name="classifier_input")
-            x_classifier = self._build_perceptron(
-                inputs, self.model_cfg["classifier"], prefix="classifier"
-            )
-            models["classification_head"] = tf.keras.Model(
-                inputs=inputs, outputs=x_classifier, name="classification_head"
-            )
-            # combine with the representation learner
-            x = models["rep_model"].output[0]
-            x = models["classification_head"](x)
-            models["jaeger_classifier"] = tf.keras.Model(
-                inputs=models["rep_model"].input, outputs=x, name="Jaeger_classifier"
-            )
+            y = self._build_head(self.model_cfg["classifier"], x)
+            models["classifier"] = tf.keras.Model(inputs=self.inputs, outputs=y)
+        else:
+            raise ValueError("Missing 'classifier' section in config")
 
-        # === 4. RELIABILITY ===
+        # === 4. RELIABILITY MODEL ===
         if "reliability_model" in self.model_cfg:
-            input_shape = (
-                self.model_cfg["representation_learner"].get("block_filters")[-1],
-            )
-            inputs = tf.keras.Input(shape=input_shape, name="reliability_input")
-            x_reliability = self._build_perceptron(
-                inputs, self.model_cfg["reliability_model"], prefix="reliability"
-            )
-            models["reliability_head"] = tf.keras.Model(
-                inputs=inputs, outputs=x_reliability, name="reliability_head"
-            )
-            # combine withe representation learner
-            x = models["rep_model"].output[1]
-            x = models["reliability_head"](x)
-            models["jaeger_reliability"] = tf.keras.Model(
-                inputs=models["rep_model"].input, outputs=x, name="Jaeger_reliability"
-            )
-
-        # ==== 5. COMBINED MODEL ====
-        x1, x2 = models["rep_model"].output
-        reliability = models["reliability_head"](x2)
-        class_ = models["classification_head"](x1)
-        models["jaeger_model"] = JaegerModel(
-            inputs=models["rep_model"].input,
-            outputs={"prediction": class_, "reliability": reliability},
-            name="Jaeger_model",
-        )
+            r = self._build_head(self.model_cfg["reliability_model"], r_lbn)
+            models["reliability"] = tf.keras.Model(inputs=self.inputs, outputs=r)
+        else:
+            raise ValueError("Missing 'reliability_model' section in config")
 
         return models
 
-    def build_contig_classifier(self):
-        """
-        to do: contig consensus prediction model
-        currently, the final predictions per-contig is obtained by averaing the
-        per-fragment logits. Instead, we can learn a function to combine information
-        from all fragments.
-        """
-        pass
-
     def _build_embedding(self, cfg: Dict[str, Any]):
-        """
-        creates the embedding layer
-        """
-        input_shape = cfg.get("input_shape", (6, None, 64))
-        embedding_size = cfg.get("embedding_size", 4)
+        """Builds the embedding layer based on config."""
+        input_shape = cfg.get("input_shape")
+        frames = cfg.get("frames", 6)
+        embedding_size = cfg.get("embedding_size", 128)
+        seq_type = cfg.get("type", "translated")
 
-        inputs = tf.keras.Input(shape=input_shape, name=cfg.get("type"))
-        masked_inputs = tf.keras.layers.Masking(name="input_mask", mask_value=0.0)(
-            inputs
-        )
+        if seq_type == "translated":
+            inputs = tf.keras.Input(shape=input_shape, name="translated_input")
+            x = inputs
+        elif seq_type == "nucleotide":
+            inputs = tf.keras.Input(shape=input_shape, name="nucleotide_input")
+            x = inputs
+        elif seq_type == "both":
+            # Handle dual input
+            inputs = tf.keras.Input(shape=input_shape, name="combined_input")
+            x = inputs
+        else:
+            raise ValueError(f"Unknown embedding type: {seq_type}")
 
-        match cfg.get("type"):
-            case "translated":
-                x = tf.keras.layers.Dense(
-                    embedding_size,
-                    name=f"{cfg.get('type')}_embedding",
-                    use_bias=False,
-                    kernel_initializer=tf.keras.initializers.Orthogonal(),
-                )(masked_inputs)
-            case "nucleotide":
-                x = masked_inputs
-            case _:
-                raise ValueError(f"{cfg.get('type')} is invalid")
         return inputs, x
 
-    def _build_representation_learner(self, x, cfg: Dict[str, Any]):
-        """
-        X -> [X'-1, X']
-        """
+    def _build_representation_learner(self, cfg: Dict[str, Any], x):
+        """Builds the representation learner (conv blocks)."""
+        block_sizes = cfg.get("block_sizes", [2, 2, 2])
+        block_filters = cfg.get("block_filters", [128, 128, 128])
+        block_kernel_size = cfg.get("block_kernel_size", [5, 5, 5])
+        block_kernel_dilation = cfg.get("block_kernel_dilation", [3, 3, 3])
+        block_kernel_strides = cfg.get("block_kernel_strides", [1, 1, 1])
+        block_regularizer = cfg.get("block_regularizer", ["l2", "l2", "l2"])
+        block_regularizer_w = cfg.get("block_regularizer_w", [0, 0, 0])
+        pooling = cfg.get("pooling", "max")
+
+        # Initial conv
         x = MaskedConv1D(
-            filters=cfg.get("masked_conv1d_1_filters"),
-            kernel_size=cfg.get("masked_conv1d_1_kernel_size"),
-            strides=cfg.get("masked_conv1d_1_strides"),
-            dilation_rate=cfg.get("masked_conv1d_1_dilation_rate"),
-            use_bias=False,
-            name="masked_conv1d_1",
-            activation=None,
+            filters=cfg.get("masked_conv1d_1_filters", 128),
+            kernel_size=cfg.get("masked_conv1d_1_kernel_size", 7),
+            strides=cfg.get("masked_conv1d_1_strides", 1),
+            dilation_rate=cfg.get("masked_conv1d_1_dilation_rate", 1),
+            padding="same",
             kernel_regularizer=self._regularizer.get(
-                cfg.get("masked_conv1d_1_regularizer"),
-            )(cfg.get("masked_conv1d_1_regularizer_w")),
-            kernel_initializer=tf.keras.initializers.HeUniform(),
+                cfg.get("masked_conv1d_1_regularizer", "l2"),
+                tf.keras.regularizers.L2,
+            )(cfg.get("masked_conv1d_1_regularizer_w", 0)),
+            name="masked_conv1d_initial",
         )(x)
-        # using batchnorm here gives a big advantage. You get a model that can work well with different input size.
-        # infact the accuracy increase with the increasing input size.
+        x = self.Activation(name="activation_initial")(x)
 
-        x = MaskedBatchNorm(name="masked_batchnorm_1")(x)
-        x = self.Activation(name="activation_1")(x)
-
-        for block, (
-            block_size,
-            block_filter,
-            ksize,
-            kdilation,
-            kstride,
-            kreg,
-            kregw,
-        ) in enumerate(
+        # Residual blocks
+        for i, (size, filters, ksize, dilation, strides, reg, reg_w) in enumerate(
             zip(
-                cfg.get("block_sizes", [3, 3, 3]),
-                cfg.get("block_filters", [128, 256, 512]),
-                cfg.get("block_kernel_size", [5, 5, 5]),
-                cfg.get("block_kernel_dilation", [1, 1, 1]),
-                cfg.get("block_kernel_strides", [2, 2, 2]),
-                cfg.get("block_regularizer", ["l2", "l2", "l2"]),
-                cfg.get("block_regularizer_w", [1e-6, 1e-6, 1e-6]),
-            ),
-            start=1,
+                block_sizes,
+                block_filters,
+                block_kernel_size,
+                block_kernel_dilation,
+                block_kernel_strides,
+                block_regularizer,
+                block_regularizer_w,
+            )
         ):
-            # ========== blockn (compress -> res) =============
-            x = MaskedConv1D(
-                filters=block_filter,
-                kernel_size=ksize,
-                strides=kstride,
-                dilation_rate=kdilation,
-                use_bias=False,
-                name=f"ds_masked_conv1d_{block}",
-                kernel_regularizer=self._regularizer.get(kreg)(kregw),
-                activation=None,
-                kernel_initializer=tf.keras.initializers.HeUniform(),
-            )(x)
-            x = MaskedBatchNorm(name=f"ds_masked_batchnorm_{block}")(x)
-            x = self.Activation(name=f"ds_activation_{block}")(x)
-
-            for i in range(block_size):
+            for j in range(size):
                 x = ResidualBlock(
-                    block_filter,
+                    filters=filters,
                     kernel_size=ksize,
-                    block_number=f"{block}{i}",
-                    name=f"masked_resblock_{block}{i}",
+                    dilation_rate=dilation,
+                    strides=strides if j == 0 else 1,
+                    kernel_regularizer=self._regularizer.get(reg, tf.keras.regularizers.L2)(
+                        reg_w
+                    ),
+                    name=f"resblock_{i}_{j}",
                 )(x)
+            if pooling == "max":
+                x = tf.keras.layers.MaxPooling1D(pool_size=2, name=f"pool_{i}")(x)
+            elif pooling == "avg":
+                x = tf.keras.layers.AveragePooling1D(pool_size=2, name=f"pool_{i}")(x)
 
-        # ============ final block ============
+        # Final conv
         x = MaskedConv1D(
-            filters=block_filter,
-            kernel_size=cfg.get("masked_conv1d_final_kernel_size"),
-            strides=cfg.get("masked_conv1d_final_strides"),
-            dilation_rate=cfg.get("masked_conv1d_final_dilation_rate"),
-            use_bias=False,
-            name="masked_conv1d_final",
+            filters=block_filters[-1],
+            kernel_size=cfg.get("masked_conv1d_final_kernel_size", 5),
+            strides=cfg.get("masked_conv1d_final_strides", 1),
+            dilation_rate=cfg.get("masked_conv1d_final_dilation_rate", 1),
+            padding="same",
             kernel_regularizer=self._regularizer.get(
-                cfg.get("masked_conv1d_final_regularizer"),
-            )(cfg.get("masked_conv1d_final_regularizer_w")),
-            activation=None,
-            kernel_initializer=tf.keras.initializers.HeUniform(),
+                cfg.get("masked_conv1d_final_regularizer", "l2"),
+                tf.keras.regularizers.L2,
+            )(cfg.get("masked_conv1d_final_regularizer_w", 0)),
+            name="masked_conv1d_final",
         )(x)
-        # this layers mean vector is used as u[train] to calculate nmd u[example] - u[train]
-        x, nmd = MaskedBatchNorm(name="masked_batchnorm_final", return_nmd=True)(x)
         x = self.Activation(name="activation_final")(x)
-        # =========== Aggregation ==============
-        x = self._get_pooler(cfg.get("pooling"))(
-            name=f"global_{cfg.get('pooling')}pool"
-        )(x)
-        return x, nmd
 
-    def _build_perceptron(self, x, cfg: Dict[str, Any], prefix: str):
-        """
-        Get an MLP for a given configuration
-        prefixes : reliability, projection, classifier
-        """
+        # Global pooling for reliability model
+        r_lbn = tf.keras.layers.GlobalAveragePooling1D(name="gap_reliability")(x)
 
-        for i, layer_cfg in enumerate(cfg.get("hidden_layers"), 1):
+        return x, r_lbn
+
+    def _build_head(self, cfg: Dict[str, Any], x):
+        """Builds a classification head."""
+        hidden_layers = cfg.get("hidden_layers", [])
+
+        for i, layer_cfg in enumerate(hidden_layers):
             x = tf.keras.layers.Dense(
-                layer_cfg.get("units"),
-                use_bias=layer_cfg.get("use_bias"),
-                name=f"{prefix}_dense_{i}",
-                # activation=layer_cfg.get("activation")
+                units=layer_cfg.get("units", 128),
+                activation=None,
+                use_bias=layer_cfg.get("use_bias", False),
+                kernel_regularizer=self._regularizer.get(
+                    layer_cfg.get("kernel_regularizer", "l2"),
+                    tf.keras.regularizers.L2,
+                )(layer_cfg.get("kernel_regularizer_w", 1e-5)),
+                name=f"dense_{i}",
             )(x)
-            x = self.Activation(name=f"{prefix}_activation_{i}")(x)
+            x = self.Activation(name=f"activation_dense_{i}")(x)
             if layer_cfg.get("dropout_rate", 0) > 0:
-                x = tf.keras.layers.Dropout(
-                    layer_cfg.get("dropout_rate"),
-                    name=f"{prefix}_dropout_{i}",
-                )(x)
+                x = tf.keras.layers.Dropout(layer_cfg["dropout_rate"], name=f"dropout_{i}")(x)
 
-        outputs = tf.keras.layers.Dense(
-            cfg.get("output_units"),
-            use_bias=layer_cfg.get("output_use_bias"),
-            name=prefix,
-            activation=cfg.get("output_activation"),
+        # Output layer
+        x = tf.keras.layers.Dense(
+            units=cfg.get("output_units", 6),
+            activation=cfg.get("output_activation", None),
+            use_bias=cfg.get("output_use_bias", False),
+            name="output",
         )(x)
-        return outputs
 
-    def _get_string_processor_config(self) -> Dict:
-        _map = {
-            "CODON": CODONS,
-            "CODON_ID": CODON_ID,
-            "AA_ID": AA_ID,
-            "MURPHY10_ID": MURPHY10_ID,
-            "PC5_ID": PC5_ID,
-            "DICODON": DICODONS,
-            "DICODON_ID": DICODON_ID,
-        }
-        _config = self.model_cfg.get("embedding")
-        _config.update(self.model_cfg.get("string_processor"))
-        # get original labels and -> mapping
+        return x
 
-        _config["codon"] = _map.get(_config.get("codon"))
-        _config["codon_id"] = _map.get(_config.get("codon_id"))
-        _config["codon_depth"] = max(_config.get("codon_id")) + 1  # num_codons
-        _config["vocab_size"] = len(_config.get("codon_id")) + 1  # num_codon + 1
-        _config["ngram_width"] = int(math.log(len(_config["codon"]), 4))
-        _config["seq_onehot"] = _config.get("seq_onehot", False)
-        if _config["seq_onehot"] is False:
-            _config["codon_depth"] = 1
-
-        return _config
-
-    def _get_pooler(self, name):
-        poolers = {
-            "max": tf.keras.layers.GlobalMaxPooling2D,
-            "average": tf.keras.layers.GlobalAveragePooling2D,
-        }
-        return poolers[name]
+    def _get_string_processor_config(self):
+        """Extract string processor config from model config."""
+        # This is a simplified version
+        return {"input_type": "translated"}
 
 
 class InferModel:
@@ -499,6 +410,146 @@ class InferModel:
             input_shape = _model_cfg.get("embedding", {}).get("input_shape")
             if _config.get("seq_onehot") is None and input_shape is not None:
                 # input_shape is [frames, timesteps, codon_depth] for one-hot
+                _config["seq_onehot"] = (
+                    len(input_shape) == 3
+                    and input_shape[-1] is not None
+                    and input_shape[-1] > 1
+                )
+            _config["seq_onehot"] = _config.get("seq_onehot", False)
+            if _config["seq_onehot"] is False:
+                _config["codon_depth"] = 1
+        return _config
+
+
+class TFLiteInferModel:
+    """
+    TFLite inference wrapper for quantized Jaeger models.
+
+    Provides the same interface as InferModel but runs inference via
+    TensorFlow Lite interpreter. Supports dynamic input resizing for
+    variable sequence lengths.
+    """
+
+    def __init__(self, path_dict):
+        self.class_map = self._load_class_map(path_dict.get("classes"))
+        self.string_processor_config = self._load_string_processor_config(
+            path_dict.get("project", None)
+        )
+
+        # Load TFLite model
+        tflite_path = path_dict.get("tflite")
+        if tflite_path is None or not Path(tflite_path).exists():
+            raise ValueError(
+                f"TFLite model not found at {tflite_path}. "
+                "Run 'jaeger utils quantize' first."
+            )
+
+        self.interpreter = tf.lite.Interpreter(model_path=str(tflite_path))
+        self.input_details = self.interpreter.get_input_details()
+        self.output_details = self.interpreter.get_output_details()
+
+    def predict(self, dataset, no_progress: bool = False) -> dict[str, np.ndarray]:
+        """
+        dataset: yields tuples (inputs_dict, meta0, meta1, …)
+        Returns a dict of numpy arrays, each of shape (N, …)
+        """
+        acc: dict[str, list[np.ndarray]] = defaultdict(list)
+
+        for inputs, *meta in track(
+            dataset, description="[cyan]Crunching data…", disable=no_progress
+        ):
+            # Get the input tensor (e.g., "translated")
+            input_type = self.string_processor_config.get("input_type", "translated")
+            x = inputs.get(input_type)
+
+            if isinstance(x, tf.Tensor):
+                x = x.numpy()
+
+            batch_size, *shape = x.shape
+
+            # Resize interpreter if needed
+            current_shape = self.input_details[0]["shape"]
+            if list(current_shape) != [batch_size, *shape]:
+                self.interpreter.resize_tensor_input(
+                    self.input_details[0]["index"], [batch_size, *shape], strict=True
+                )
+                self.interpreter.allocate_tensors()
+                # Refresh details after resize
+                self.input_details = self.interpreter.get_input_details()
+                self.output_details = self.interpreter.get_output_details()
+
+            # Set input and invoke
+            self.interpreter.set_tensor(self.input_details[0]["index"], x)
+            self.interpreter.invoke()
+
+            # Get outputs - map to same keys as SavedModel
+            # Output order: prediction, reliability (based on our conversion)
+            pred = self.interpreter.get_tensor(self.output_details[0]["index"])
+            rel = self.interpreter.get_tensor(self.output_details[1]["index"])
+
+            acc["prediction"].append(pred)
+            acc["reliability"].append(rel)
+
+            # meta data
+            for idx, m in enumerate(meta):
+                if isinstance(m, tf.Tensor):
+                    m = m.numpy()
+                acc[f"meta_{idx}"].append(m)
+
+        # concatenate arrays; keep lists for non-array metadata
+        result: dict[str, np.ndarray] = {}
+        for k, arr_list in acc.items():
+            if k.startswith("meta_"):
+                # Metadata may be strings or other non-array types
+                try:
+                    result[k] = np.concatenate(arr_list, axis=0)
+                except ValueError:
+                    result[k] = arr_list  # Keep as list if concatenation fails
+            else:
+                result[k] = np.concatenate(arr_list, axis=0)
+        return result
+
+    def evaluate(self, dataset, no_progress: bool = False) -> dict[str, float]:
+        """Evaluate on a dataset. Not yet implemented for TFLite."""
+        raise NotImplementedError("TFLite evaluation not yet implemented")
+
+    def _load_class_map(self, path):
+        with open(path) as f:
+            _class_map = yaml.safe_load(f)["classes"]
+            return {
+                "num_classes": len(_class_map),
+                "class": [i["class"] for i in _class_map],
+                "index": [i["label"] for i in _class_map],
+            }
+
+    def _load_string_processor_config(self, path) -> Dict:
+        _map = {
+            "CODON": CODONS,
+            "CODON_ID": CODON_ID,
+            "AA_ID": AA_ID,
+            "MURPHY10_ID": MURPHY10_ID,
+            "PC5_ID": PC5_ID,
+            "DICODON": DICODONS,
+            "DICODON_ID": DICODON_ID,
+        }
+
+        if path is None:
+            return {"input_type": "translated"}
+
+        _config = yaml.safe_load(Path(path).read_text()) or {}
+        _model_cfg = _config.get("model")
+        _config = _model_cfg.get("embedding")
+        _config.update(_model_cfg.get("string_processor"))
+        _config["input_type"] = _config.get("type", "translated")
+
+        if _config["codon"] is not None and _config["codon_id"] is not None:
+            _config["codon"] = _map.get(_config.get("codon"))
+            _config["codon_id"] = _map.get(_config.get("codon_id"))
+            _config["codon_depth"] = max(_config.get("codon_id")) + 1
+            _config["vocab_size"] = len(_config.get("codon_id")) + 1
+            _config["ngram_width"] = int(math.log(len(_config["codon"]), 4))
+            input_shape = _model_cfg.get("embedding", {}).get("input_shape")
+            if _config.get("seq_onehot") is None and input_shape is not None:
                 _config["seq_onehot"] = (
                     len(input_shape) == 3
                     and input_shape[-1] is not None

--- a/src/jaeger/nnlib/inference.py
+++ b/src/jaeger/nnlib/inference.py
@@ -388,9 +388,12 @@ class InferModel:
         """
         dataset: yields tuples (inputs_dict, meta0, meta1, …)
         Returns a dict of numpy arrays, each of shape (N, …)
+
+        To avoid GPU OOM on large datasets, each batch is moved to host
+        (CPU) memory immediately after inference.
         """
-        # accumulate TF tensors
-        acc: dict[str, list[tf.Tensor]] = defaultdict(list)
+        # accumulate NumPy arrays on CPU — prevents GPU memory growth
+        acc: dict[str, list[np.ndarray]] = defaultdict(list)
 
         # inline for speed
         inf_fn = self._predict_step
@@ -401,30 +404,29 @@ class InferModel:
             # call the tf.function
             logits = inf_fn(inputs)
 
-            # collect all logits tensors
+            # move logits to CPU immediately to bound GPU memory usage
             for k, t in logits.items():
-                acc[k].append(t)
+                acc[k].append(t.numpy())
 
-            # collect meta tensors
+            # meta data is already on CPU (strings / python objects)
             for idx, m in enumerate(meta):
                 acc[f"meta_{idx}"].append(m)
 
-        # now concatenate once per key, then move to NumPy
+        # concatenate NumPy arrays on CPU
         result: dict[str, np.ndarray] = {}
-        for k, tensor_list in acc.items():
-            # tf.concat stays on device, one pass
-            cat = tf.concat(tensor_list, axis=0)
-            # then one host-device copy per key
-            result[k] = cat.numpy()
+        for k, arr_list in acc.items():
+            result[k] = np.concatenate(arr_list, axis=0)
         return result
 
     def evaluate(self, dataset, no_progress: bool = False) -> dict[str, float]:
         """
         dataset: yields tuples (inputs_dict, y_true_onehot)
         Returns loss and accuracy
+
+        Moves each batch to CPU immediately to avoid GPU OOM.
         """
-        logits_acc: list[tf.Tensor] = []
-        true_acc: list[tf.Tensor] = []
+        logits_acc: list[np.ndarray] = []
+        true_acc: list[np.ndarray] = []
 
         inf_fn = self._predict_step
 
@@ -432,12 +434,13 @@ class InferModel:
             dataset, description="[cyan]Evaluating…", disable=no_progress
         ):
             logits = inf_fn(inputs)["prediction"]
-            logits_acc.append(logits)
-            true_acc.append(y_true)
+            # move to CPU immediately
+            logits_acc.append(logits.numpy())
+            true_acc.append(y_true.numpy())
 
-        # bulk-concatenate and to NumPy once
-        logits = tf.concat(logits_acc, axis=0).numpy()
-        y_true = tf.concat(true_acc, axis=0).numpy()
+        # concatenate on CPU
+        logits = np.concatenate(logits_acc, axis=0)
+        y_true = np.concatenate(true_acc, axis=0)
 
         # loss & accuracy
         loss = tf.keras.losses.categorical_crossentropy(

--- a/src/jaeger/postprocess/collect.py
+++ b/src/jaeger/postprocess/collect.py
@@ -495,14 +495,16 @@ def write_output(data: Dict, reliability_cutoff: float = 0.5, phage_score=1, **k
     )
 
     # Save only phage-related sequences
-    # df.query(
-    #     f'(prediction == "phage") and (phage_score > {phage_score}) and (reliability_score > {reliability_cutoff})'
-    # ).to_csv(
-    #     kwargs.get("output_phage_table_path"),
-    #     sep="\t",
-    #     index=False,
-    #     float_format="%.3f",
-    # )
+    phage_df = df.query(
+        f'(prediction == "phage") and (phage_score > {phage_score}) and (reliability_score > {reliability_cutoff})'
+    )
+    if not phage_df.empty:
+        phage_df.to_csv(
+            kwargs.get("output_phage_table_path"),
+            sep="\t",
+            index=False,
+            float_format="%.3f",
+        )
     return len(df)
     # logger.info("Summary generation completed!")
     # except Exception as e:
@@ -527,10 +529,11 @@ def write_fasta_from_results(
     """
 
     logger.info(f"generating fasta file {output_fasta}")
-    phages = set(pd.read_table(output_tsv)["contig_id"].to_list())
-    phage_fasta = open(output_fasta, "w")
-    for record in pyfastx.Fasta(input_fasta, build_index=False):
-        if record[0] in phages:
-            phage_fasta.write(f">{record[0]}\n")
-            for i in range(0, len(record), width):
-                phage_fasta.write(f">{record[0][i : i + width]}\n")
+    phages = set(pd.read_table(str(output_tsv))["contig_id"].to_list())
+    with open(str(output_fasta), "w") as phage_fasta:
+        for record in pyfastx.Fasta(str(input_fasta), build_index=False):
+            if record[0] in phages:
+                phage_fasta.write(f">{record[0]}\n")
+                seq = record[1]
+                for i in range(0, len(seq), width):
+                    phage_fasta.write(f"{seq[i : i + width]}\n")

--- a/src/jaeger/postprocess/prophages.py
+++ b/src/jaeger/postprocess/prophages.py
@@ -69,19 +69,82 @@ def logits_to_df(config: Any, cmdline_kwargs: Dict, **kwargs) -> Dict:
             )
 
             for k, v in lab.items():
-                t[v] = np.convolve(value[:, k], np.ones(4), mode="same")
-            t["gc"] = gc
-            t["gc_skew"] = scale_range(
-                np.convolve(np.array(gc_skew), np.ones(10) / 10, mode="same"),
-                min=-1,
-                max=1,
-            )
+                conv = np.convolve(value[:, k], np.ones(4), mode="same")
+                # trim/pad to match the number of windows
+                if len(conv) > len(t):
+                    conv = conv[: len(t)]
+                elif len(conv) < len(t):
+                    conv = np.pad(conv, (0, len(t) - len(conv)), mode="edge")
+                t[v] = conv
+            t["gc"] = gc[: len(t)] if len(gc) > len(t) else gc
+            gc_skew_conv = np.convolve(np.array(gc_skew), np.ones(10) / 10, mode="same")
+            if len(gc_skew_conv) > len(t):
+                gc_skew_conv = gc_skew_conv[: len(t)]
+            elif len(gc_skew_conv) < len(t):
+                gc_skew_conv = np.pad(
+                    gc_skew_conv, (0, len(t) - len(gc_skew_conv)), mode="edge"
+                )
+            t["gc_skew"] = scale_range(gc_skew_conv, min=-1, max=1)
 
             tmp[f"{key}"] = [t, host, length]
         # except Exception as e:
         #     logger.error(e)
         #     logger.debug(traceback.format_exc())
 
+    return tmp
+
+
+def logits_to_df_v2(
+    class_map: dict,
+    cmdline_kwargs: dict,
+    headers: np.ndarray,
+    predictions: list[np.ndarray],
+    lengths: np.ndarray,
+    gc_skews: list[np.ndarray],
+    gcs: list[np.ndarray],
+) -> dict:
+    """Convert logits to a dict of dataframes for prophage region identification.
+
+    Compatible with the new SavedModel / TFLite / ONNX pipeline.
+    Uses ``class_map`` (with ``class`` and ``index`` keys) instead of the
+    legacy ``config["all_labels"]`` dict.
+
+    Returns:
+        Dict mapping contig_id -> [DataFrame, host_label, length]
+    """
+    indices = class_map.get("index", [])
+    classes = class_map.get("class", [])
+    lab = {int(i): c for i, c in zip(indices, classes)}
+
+    tmp = {}
+    for key, value, length, gc_skew, gc in zip(
+        headers, predictions, lengths, gc_skews, gcs
+    ):
+        if length >= cmdline_kwargs.get("lc", 500_000):
+            value = np.exp(value) / np.sum(np.exp(value), axis=1).reshape(-1, 1)
+            max_class = np.argmax(np.mean(value, axis=0))
+            host = lab.get(max_class, "unknown")
+            t = pd.DataFrame(value, columns=list(lab.values()))
+            t = t.assign(
+                length=[i * cmdline_kwargs.get("fsize", 2000) for i in range(len(t))]
+            )
+            for k, v in lab.items():
+                conv = np.convolve(value[:, k], np.ones(4), mode="same")
+                if len(conv) > len(t):
+                    conv = conv[: len(t)]
+                elif len(conv) < len(t):
+                    conv = np.pad(conv, (0, len(t) - len(conv)), mode="edge")
+                t[v] = conv
+            t["gc"] = gc[: len(t)] if len(gc) > len(t) else gc
+            gc_skew_conv = np.convolve(np.array(gc_skew), np.ones(10) / 10, mode="same")
+            if len(gc_skew_conv) > len(t):
+                gc_skew_conv = gc_skew_conv[: len(t)]
+            elif len(gc_skew_conv) < len(t):
+                gc_skew_conv = np.pad(
+                    gc_skew_conv, (0, len(t) - len(gc_skew_conv)), mode="edge"
+                )
+            t["gc_skew"] = scale_range(gc_skew_conv, min=-1, max=1)
+            tmp[f"{key}"] = [t, host, length]
     return tmp
 
 
@@ -135,7 +198,7 @@ def plot_scores(
         outer_track.xticks_by_interval(
             minor_ticks_interval, tick_length=1, show_label=False, label_size=11
         )
-        colors = ["gray", "green", "red", "teal", "brown"]
+        colors = ["gray", "green", "red", "teal", "brown", "purple", "cyan", "pink"]
         patches = []
 
         for j, v in enumerate(lab.values()):
@@ -163,16 +226,17 @@ def plot_scores(
                         lw=1,
                     )
             else:
+                color = colors[j % len(colors)]
                 aux_track = sector.add_track((78, 87), r_pad_ratio=0.1)
                 aux_track.fill_between(
                     tmp["length"],
                     tmp[v].to_numpy(),
                     vmin=0,
                     vmax=4,
-                    color=colors[j],
+                    color=color,
                     alpha=0.7,
                 )
-                patches.append(Patch(color=colors[j], label=v))
+                patches.append(Patch(color=color, label=v))
 
         # Plot G+C
         gc_content_track = sector.add_track((55, 70))

--- a/src/jaeger/postprocess/prophages.py
+++ b/src/jaeger/postprocess/prophages.py
@@ -345,6 +345,162 @@ def plot_scores(
         plt.close()
 
 
+def plot_scores_linear(
+    logits_df: pd.DataFrame,
+    config: Any,
+    model: str,
+    fsize: int,
+    infile_base: str,
+    outdir: Path,
+    phage_cordinates: Dict,
+) -> None:
+    """
+    Creates a linear genome plot of the host genome including putative
+    prophages identified by Jaeger.
+
+    Args:
+    ----
+        logits_df: DataFrame containing the logits.
+        config: Dictionary containing configuration settings.
+        model: Model identifier string.
+        fsize: Fragment size in bp.
+        infile_base: Base name of the input file.
+        outdir: Output directory for saving the plot.
+        phage_cordinates: Dictionary of phage coordinates.
+
+    Returns:
+    -------
+        None
+    """
+    lab = {int(k): v for k, v in config["all_labels"].items()}
+    colors = ["gray", "green", "red", "teal", "brown", "purple", "pink", "olive"]
+
+    for contig_id in logits_df.keys():
+        tmp, host, length = logits_df[contig_id]
+        fig, axes = plt.subplots(
+            nrows=4,
+            ncols=1,
+            figsize=(14, 10),
+            sharex=True,
+            gridspec_kw={"height_ratios": [2, 2, 1.5, 1.5], "hspace": 0.05},
+        )
+        ax_phage, ax_aux, ax_gc, ax_skew = axes
+
+        # --- Phage score track (top) ---
+        ax_phage.fill_between(
+            tmp["length"],
+            tmp["phage"].to_numpy(),
+            color="orange",
+            alpha=0.8,
+            label="phage score",
+        )
+        # Highlight prophage regions
+        for cords in phage_cordinates.get(contig_id, [[], []])[0]:
+            pcs = np.arange(cords[0], cords[-1]) * fsize
+            ax_phage.fill_between(
+                pcs,
+                np.ones_like(pcs) * 4,
+                color="magenta",
+                alpha=0.25,
+                label="putative prophage"
+                if cords[0] == phage_cordinates[contig_id][0][0][0]
+                else "",
+            )
+        ax_phage.set_ylim(0, 4)
+        ax_phage.set_ylabel("Phage score", fontsize=10)
+        ax_phage.set_title(
+            f"{contig_id.replace('___', ',')}",
+            fontdict={"size": 12, "weight": "bold"},
+        )
+        ax_phage.legend(loc="upper right", fontsize=8)
+        ax_phage.grid(True, linestyle=":", alpha=0.4)
+
+        # --- Auxiliary class scores ---
+        patches = []
+        for j, v in enumerate(lab.values()):
+            if v == "phage":
+                continue
+            ax_aux.plot(
+                tmp["length"],
+                tmp[v].to_numpy(),
+                color=colors[j % len(colors)],
+                alpha=0.7,
+                linewidth=1.2,
+                label=v,
+            )
+            patches.append(Patch(color=colors[j % len(colors)], label=v))
+        ax_aux.set_ylim(0, 4)
+        ax_aux.set_ylabel("Class scores", fontsize=10)
+        ax_aux.legend(loc="upper right", fontsize=8)
+        ax_aux.grid(True, linestyle=":", alpha=0.4)
+
+        # --- GC content track ---
+        gc_centered = tmp["gc"] - tmp["gc"].mean()
+        positive_gc = np.where(gc_centered > 0, gc_centered, 0)
+        negative_gc = np.where(gc_centered < 0, gc_centered, 0)
+        abs_max_gc = np.max(np.abs(gc_centered))
+        vmin_gc, vmax_gc = -abs_max_gc, abs_max_gc
+
+        ax_gc.fill_between(
+            tmp["length"],
+            positive_gc,
+            0,
+            color="blue",
+            alpha=0.5,
+            label=r"$> \overline{G+C}$",
+        )
+        ax_gc.fill_between(
+            tmp["length"],
+            negative_gc,
+            0,
+            color="black",
+            alpha=0.7,
+            label=r"$< \overline{G+C}$",
+        )
+        ax_gc.set_ylim(vmin_gc, vmax_gc)
+        ax_gc.set_ylabel("G+C dev.", fontsize=10)
+        ax_gc.legend(loc="upper right", fontsize=8)
+        ax_gc.grid(True, linestyle=":", alpha=0.4)
+
+        # --- GC skew track ---
+        positive_skew = np.where(tmp["gc_skew"] > 0, tmp["gc_skew"], 0)
+        negative_skew = np.where(tmp["gc_skew"] < 0, tmp["gc_skew"], 0)
+        abs_max_skew = np.max(np.abs(tmp["gc_skew"]))
+        vmin_skew, vmax_skew = -abs_max_skew, abs_max_skew
+
+        ax_skew.fill_between(
+            tmp["length"],
+            positive_skew,
+            0,
+            color="olive",
+            alpha=0.7,
+            label="Positive GC skew",
+        )
+        ax_skew.fill_between(
+            tmp["length"],
+            negative_skew,
+            0,
+            color="purple",
+            alpha=0.7,
+            label="Negative GC skew",
+        )
+        ax_skew.set_ylim(vmin_skew, vmax_skew)
+        ax_skew.set_ylabel("GC skew", fontsize=10)
+        ax_skew.set_xlabel("Genome position (bp)", fontsize=10)
+        ax_skew.legend(loc="upper right", fontsize=8)
+        ax_skew.grid(True, linestyle=":", alpha=0.4)
+
+        # Format x-axis
+        ax_skew.xaxis.set_major_formatter(
+            plt.FuncFormatter(lambda x, _: f"{x / 1e6:.1f} Mb")
+        )
+
+        out_path = outdir / f"{infile_base}_jaeger_{contig_id.split(' ')[0]}_linear.pdf"
+        plt.savefig(out_path, bbox_inches="tight", dpi=300)
+        logger.info(f"linear prophage plot saved at {out_path}")
+        plt.close()
+
+
 def segment(
     logits_df: pd.DataFrame,
     outdir: Path,


### PR DESCRIPTION
## Summary

This PR adds linear genome plot support for prophage visualization and wires prophage extraction into the new inference pipeline (`predict.py`).

## Changes

### Linear genome plots (`--plot-type`)
- New `--plot-type` CLI option: `circular` (default) | `linear` | `both` | `none`
- `plot_scores_linear()` in `prophages.py`: 4-panel horizontal layout
  - Panel 1: Phage score track with magenta prophage highlights
  - Panel 2: Other class scores (bacteria, eukarya, archaea)
  - Panel 3: GC content deviation from mean
  - Panel 4: GC skew
- Linear plots saved as `{prefix}_linear.pdf`
- Works in both `predict.py` (non-default models) and `predict_legacy.py` (default model)

### Prophage prediction in new pipeline
- `predict.py` now supports `--prophage`, `--sensitivity`, `--lc`, `--getsequences`, `--getalllogits`
- Uses `logits_to_df_v2()` for the new pipeline

### Bug fixes
- Fixed `plot_scores()` color assignment for 6+ classes
- Fixed `np.convolve` length mismatch in `logits_to_df_v2()`
- Fixed `write_fasta_from_results()` pyfastx Path→str issue

### Docs
- Updated `docs/_source/usage.md` with `--plot-type` examples and plot type table

## Testing
- Mock data tests confirm both circular and linear plots render correctly
- `jaeger predict --help` shows the new option
- `ruff check` / `ruff format` pass on all modified files

## Backward compatibility
- Default `--plot-type circular` preserves existing behavior
- All existing CLI options unchanged